### PR TITLE
Set @moduledoc false on generated modules

### DIFF
--- a/priv/templates/enum.ex.eex
+++ b/priv/templates/enum.ex.eex
@@ -1,4 +1,5 @@
 defmodule <%= name %> do
+  @moduledoc false
   use Protobuf<%= options %>
 
 <%= Enum.map fields, fn(field) -> %>

--- a/priv/templates/message.ex.eex
+++ b/priv/templates/message.ex.eex
@@ -1,4 +1,5 @@
 defmodule <%= name %> do
+  @moduledoc false
   use Protobuf<%= options %>
 
   <%= typespec %>

--- a/priv/templates/service.ex.eex
+++ b/priv/templates/service.ex.eex
@@ -1,4 +1,5 @@
 defmodule <%= mod_name %>.Service do
+  @moduledoc false
   use GRPC.Service, name: <%= inspect(name) %>
 
 <%= Enum.map methods, fn(method) -> %>
@@ -7,5 +8,6 @@ defmodule <%= mod_name %>.Service do
 end
 
 defmodule <%= mod_name %>.Stub do
+  @moduledoc false
   use GRPC.Stub, service: <%= mod_name %>.Service
 end


### PR DESCRIPTION
Modules generated by protoc are not documented but still appear in ex_doc documentation. Defaulting to `@moduledoc false` hides the generated modules from ex_doc. I think in most cases messages/enums/services will be internal implementation details to the projects using them and won't be documented. Docs can still be added after generating the modules but this seems like a better default.