### PR TITLE
Fix scalar types in oneof for proto3

### DIFF
--- a/lib/protobuf/validator.ex
+++ b/lib/protobuf/validator.ex
@@ -38,6 +38,8 @@ defmodule Protobuf.Validator do
       type_valid?(key_type, k) && match_and_valid?(val_type, v)
     end)
   end
+  # oneof fields are not present in struct
+  def field_valid?(_, %{oneof: oneof}, nil) when is_integer(oneof), do: true
   # nil is allowed for singular embedded message
   def field_valid?(_, %{embedded?: true}, nil), do: true
   def field_valid?(_, %{embedded?: true, type: type}, val) do

--- a/test/protobuf/validator_test.exs
+++ b/test/protobuf/validator_test.exs
@@ -7,6 +7,11 @@ defmodule Protobuf.ValidatorTest do
     assert true = Protobuf.Validator.valid?(msg)
   end
 
+  test "oneof valid for valid tuple and nil when syntax = proto3" do
+    msg = TestMsg.OneofProto3.new(first: {:a, 42})
+    assert true = Protobuf.Validator.valid?(msg)
+  end
+
   test "oneof invalid format" do
     msg = TestMsg.Oneof.new(first: 1)
     assert {:invalid, error} = Protobuf.Validator.valid?(msg)

--- a/test/support/test_msg.ex
+++ b/test/support/test_msg.ex
@@ -85,6 +85,20 @@ defmodule TestMsg do
     field :other, 5, optional: true, type: :string
   end
 
+  defmodule OneofProto3 do
+    use Protobuf, syntax: :proto3
+
+    defstruct [:first, :second, :other]
+
+    oneof :first, 0
+    oneof :second, 1
+    field :a, 1, optional: true, type: :int32, oneof: 0
+    field :b, 2, optional: true, type: :string, oneof: 0
+    field :c, 3, optional: true, type: :int32, oneof: 1
+    field :d, 4, optional: true, type: :string, oneof: 1
+    field :other, 5, optional: true, type: :string
+  end
+
   defmodule Parent do
     use Protobuf, syntax: :proto3
     defstruct [:child]


### PR DESCRIPTION
### Example module:
```elixir
defmodule Oneof do
   use Protobuf, syntax: :proto3

   defstruct [:option]

   oneof :option, 0
   field :option_a, 1, optional: true, type: :string, oneof: 0
   field :option_b, 2, optional: true, type: :int32, oneof: 0
end
```

### Current behaviour (master branch):
```elixir
> Oneof.new(option: {:option_a, "string"}) |> Oneof.encode()
** (Protobuf.InvalidError) Oneof#option_a is invalid!
```

### Reason
Oneof fields are not present in generated struct and Map.get/1 in validator returns nil which is not allowed value for scalar types in proto3
