### PR TITLE
Use macro to centralize wire types declaration

### DIFF
--- a/lib/protobuf/encoder.ex
+++ b/lib/protobuf/encoder.ex
@@ -1,13 +1,8 @@
 defmodule Protobuf.Encoder do
+  import Protobuf.WireTypes
   import Bitwise, only: [bsr: 2, band: 2, bsl: 2, bor: 2]
-  alias Protobuf.{MessageProps, FieldProps}
 
-  @wire_varint       0
-  @wire_64bits       1
-  @wire_delimited    2
-  # @wire_start_group  3
-  # @wire_end_group    4
-  @wire_32bits       5
+  alias Protobuf.{MessageProps, FieldProps}
 
   @spec encode(struct, keyword) :: iodata
   def encode(%{__struct__: mod} = struct, opts \\ []) do
@@ -58,7 +53,7 @@ defmodule Protobuf.Encoder do
   end
 
   @spec class_field(map) :: atom
-  def class_field(%{wire_type: @wire_delimited, embedded?: true}) do
+  def class_field(%{wire_type: wire_delimited(), embedded?: true}) do
     :embedded
   end
   def class_field(%{repeated?: true, packed?: true}) do
@@ -112,23 +107,23 @@ defmodule Protobuf.Encoder do
   def encode_varint(n) when n > 127, do: <<1::1, band(n, 127)::7, encode_varint(bsr(n, 7))::binary>>
 
   @spec wire_type(atom) :: integer
-  def wire_type(:int32),     do: @wire_varint
-  def wire_type(:int64),     do: @wire_varint
-  def wire_type(:uint32),    do: @wire_varint
-  def wire_type(:uint64),    do: @wire_varint
-  def wire_type(:sint32),    do: @wire_varint
-  def wire_type(:sint64),    do: @wire_varint
-  def wire_type(:bool),      do: @wire_varint
-  def wire_type(:enum),      do: @wire_varint
-  def wire_type(:fixed64),   do: @wire_64bits
-  def wire_type(:sfixed64),  do: @wire_64bits
-  def wire_type(:double),    do: @wire_64bits
-  def wire_type(:string),    do: @wire_delimited
-  def wire_type(:bytes),     do: @wire_delimited
-  def wire_type(:fixed32),   do: @wire_32bits
-  def wire_type(:sfixed32),  do: @wire_32bits
-  def wire_type(:float),     do: @wire_32bits
-  def wire_type(mod) when is_atom(mod), do: @wire_delimited
+  def wire_type(:int32),     do: wire_varint()
+  def wire_type(:int64),     do: wire_varint()
+  def wire_type(:uint32),    do: wire_varint()
+  def wire_type(:uint64),    do: wire_varint()
+  def wire_type(:sint32),    do: wire_varint()
+  def wire_type(:sint64),    do: wire_varint()
+  def wire_type(:bool),      do: wire_varint()
+  def wire_type(:enum),      do: wire_varint()
+  def wire_type(:fixed64),   do: wire_64bits()
+  def wire_type(:sfixed64),  do: wire_64bits()
+  def wire_type(:double),    do: wire_64bits()
+  def wire_type(:string),    do: wire_delimited()
+  def wire_type(:bytes),     do: wire_delimited()
+  def wire_type(:fixed32),   do: wire_32bits()
+  def wire_type(:sfixed32),  do: wire_32bits()
+  def wire_type(:float),     do: wire_32bits()
+  def wire_type(mod) when is_atom(mod), do: wire_delimited()
 
   defp repeated_or_not(val, repeated, func) do
     if repeated do

--- a/lib/protobuf/wire_types.ex
+++ b/lib/protobuf/wire_types.ex
@@ -1,0 +1,12 @@
+defmodule Protobuf.WireTypes do
+  @moduledoc """
+  Protocol buffer wire types.
+  """
+
+  defmacro wire_varint, do: 0
+  defmacro wire_64bits, do: 1
+  defmacro wire_delimited, do: 2
+  # defmacro wire_start_group, do: 3
+  # defmacro wire_end_group, do: 4
+  defmacro wire_32bits, do: 5
+end


### PR DESCRIPTION
As we discussed/discovered the other day, we can use `defmacro` to define these constant and use them just fine in binary-pattern-matching.

Added `()` after macro call for clear marking, actual not sure whether it will work without `()`... 