### PR TITLE
Add a failing oneof test case

### DIFF
--- a/test/protobuf/issue_test.exs
+++ b/test/protobuf/issue_test.exs
@@ -1,0 +1,12 @@
+Code.require_file("../support/test_msg.ex", __DIR__)
+
+defmodule Protobuf.IssueTest do
+  use ExUnit.Case, async: true
+
+  alias Protobuf.{Decoder, Encoder}
+
+  test "oneof proto3" do
+    msg = %TestMsg.OneofProto3{first: {:b, ""}, second: {:c, 0}, other: "other"}
+    assert msg == msg |> Encoder.encode() |> Decoder.decode(TestMsg.OneofProto3)
+  end
+end


### PR DESCRIPTION
```
  1) test oneof proto3 (Protobuf.IssueTest)
     test/protobuf/issue_test.exs:8
     Assertion with == failed
     code:  assert msg == msg |> Encoder.encode() |> Decoder.decode(TestMsg.OneofProto3)
     left:  %TestMsg.OneofProto3{other: "other", first: {:b, ""}, second: {:c, 0}}
     right: %TestMsg.OneofProto3{other: "other", first: nil, second: nil}
     stacktrace:
       test/protobuf/issue_test.exs:10: (test)
```