### PR TITLE
Generate typespecs for messages with no fields

### DIFF
--- a/lib/protobuf/protoc/generator/message.ex
+++ b/lib/protobuf/protoc/generator/message.ex
@@ -77,7 +77,7 @@ defmodule Protobuf.Protoc.Generator.Message do
     Enum.map_join(struct.oneof_decl ++ fields, ", ", fn f -> ":#{f.name}" end)
   end
 
-  def typespec_str([], []), do: ""
+  def typespec_str([], []), do: "  @type t :: %__MODULE__{}\n"
 
   def typespec_str(fields, oneofs) do
     longest_field = fields |> Enum.max_by(&String.length(&1[:name]))

--- a/test/protobuf/protoc/generator/message_test.exs
+++ b/test/protobuf/protoc/generator/message_test.exs
@@ -10,6 +10,7 @@ defmodule Protobuf.Protoc.Generator.MessageTest do
     [msg] = Generator.generate(ctx, desc)
     assert msg =~ "defmodule Foo do\n"
     assert msg =~ "use Protobuf\n"
+    assert msg =~ "@type t :: %__MODULE__{}\n"
   end
 
   test "generate/2 has right syntax" do
@@ -18,6 +19,7 @@ defmodule Protobuf.Protoc.Generator.MessageTest do
     [msg] = Generator.generate(ctx, desc)
     assert msg =~ "defmodule Foo do\n"
     assert msg =~ "use Protobuf, syntax: :proto3\n"
+    assert msg =~ "@type t :: %__MODULE__{}\n"
   end
 
   test "generate/2 has right name with package" do


### PR DESCRIPTION
Messages without fields still need typespecs, especially if those messages types are referenced from other message types.