### PR TITLE
supports atom value for string field

### DIFF
--- a/lib/protobuf/encoder.ex
+++ b/lib/protobuf/encoder.ex
@@ -119,6 +119,7 @@ defmodule Protobuf.Encoder do
     <<len::binary, bin::binary>>
   end
 
+  def encode_type(:string, n) when is_atom(n), do: encode_type(:bytes, to_string(n))
   def encode_type(:string, n), do: encode_type(:bytes, n)
   def encode_type(:fixed32, n), do: <<n::32-little>>
   def encode_type(:sfixed32, n), do: <<n::32-signed-little>>


### PR DESCRIPTION
It is very convenience that supports atom value for string field

message Foo {
  string status = 1;
}

Foo.new(status: :ok)
|> Foo.encode()
|> Foo.encode()

==> %Foo{status: "ok"}