### PR TITLE
Add descriptors to generated protos

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,17 @@ Note:
 - Default values will be set by default in `decode`, which can be changed by `:use_default` option.
 - Validation is done in `encode`. An error will be raised if the struct is invalid(like type is not matched).
 
+### Descriptor support
+
+If you use any custom options in your protobufs then to gain access to them you'll need to include the raw descriptors in the generated modules. You can generate the descriptors by passing `gen_descriptors=true` in `--elixir_out`.
+
+The descriptors will be available on each module from the `descriptor/0` function.
+
+```
+$ protoc --elixir_out=gen_descriptors=true:./lib/ *.proto
+$ protoc --elixir_out=gen_descriptors=true,plugins=grpc:./lib/ *.proto
+```
+
 ### gRPC Support
 
 If you write [services](https://developers.google.com/protocol-buffers/docs/proto#services) in protobuf, you can generate [gRPC](https://github.com/tony612/grpc-elixir) code by passing `plugins=grpc` in `--elixir_out`:

--- a/lib/google/descriptor.pb.ex
+++ b/lib/google/descriptor.pb.ex
@@ -381,7 +381,7 @@ defmodule Google.Protobuf.FileOptions do
   field :optimize_for, 9,
     optional: true,
     type: Google.Protobuf.FileOptions.OptimizeMode,
-    default: :SPEED,
+    default: 1,
     enum: true
 
   field :go_package, 11, optional: true, type: :string
@@ -455,7 +455,7 @@ defmodule Google.Protobuf.FieldOptions do
   field :ctype, 1,
     optional: true,
     type: Google.Protobuf.FieldOptions.CType,
-    default: :STRING,
+    default: 0,
     enum: true
 
   field :packed, 2, optional: true, type: :bool
@@ -463,7 +463,7 @@ defmodule Google.Protobuf.FieldOptions do
   field :jstype, 6,
     optional: true,
     type: Google.Protobuf.FieldOptions.JSType,
-    default: :JS_NORMAL,
+    default: 0,
     enum: true
 
   field :lazy, 5, optional: true, type: :bool, default: false
@@ -562,7 +562,7 @@ defmodule Google.Protobuf.MethodOptions do
   field :idempotency_level, 34,
     optional: true,
     type: Google.Protobuf.MethodOptions.IdempotencyLevel,
-    default: :IDEMPOTENCY_UNKNOWN,
+    default: 0,
     enum: true
 
   field :uninterpreted_option, 999, repeated: true, type: Google.Protobuf.UninterpretedOption

--- a/lib/protobuf/protoc/cli.ex
+++ b/lib/protobuf/protoc/cli.ex
@@ -32,6 +32,11 @@ defmodule Protobuf.Protoc.CLI do
     parse_params(ctx, t)
   end
 
+  def parse_params(ctx, ["gen_descriptors=true" | t]) do
+    ctx = %{ctx | gen_descriptors?: true}
+    parse_params(ctx, t)
+  end
+
   def parse_params(ctx, _), do: ctx
 
   def find_types(ctx, descs) do

--- a/lib/protobuf/protoc/cli.ex
+++ b/lib/protobuf/protoc/cli.ex
@@ -5,7 +5,7 @@ defmodule Protobuf.Protoc.CLI do
     bin = IO.binread(:all)
     request = Protobuf.Decoder.decode(bin, Google.Protobuf.Compiler.CodeGeneratorRequest)
     # debug
-    # raise inspect(request, limit: :infinity)
+     # raise inspect(request, limit: :infinity)
 
     ctx =
       %Protobuf.Protoc.Context{}

--- a/lib/protobuf/protoc/context.ex
+++ b/lib/protobuf/protoc/context.ex
@@ -20,5 +20,10 @@ defmodule Protobuf.Protoc.Context do
 
             # For a message
             # Nested namespace when generating nested messages. It should be joined to get the full namespace
-            namespace: []
+            namespace: [],
+
+            # Include binary descriptors in the generated protobuf modules
+            # And expose them via the `descriptor/0` function
+            gen_descriptors?: false
+
 end

--- a/lib/protobuf/protoc/generator/enum.ex
+++ b/lib/protobuf/protoc/generator/enum.ex
@@ -9,7 +9,9 @@ defmodule Protobuf.Protoc.Generator.Enum do
     name = Util.trans_name(desc.name)
     fields = Enum.map(desc.value, fn f -> generate_field(f) end)
     msg_name = Util.mod_name(ctx, ns ++ [name])
-    Protobuf.Protoc.Template.enum(msg_name, msg_opts(ctx, desc), fields, desc)
+    generate_desc = if ctx.gen_descriptors?, do: desc, else: nil
+
+    Protobuf.Protoc.Template.enum(msg_name, msg_opts(ctx, desc), fields, generate_desc)
   end
 
   def generate_field(f) do

--- a/lib/protobuf/protoc/generator/enum.ex
+++ b/lib/protobuf/protoc/generator/enum.ex
@@ -9,14 +9,14 @@ defmodule Protobuf.Protoc.Generator.Enum do
     name = Util.trans_name(desc.name)
     fields = Enum.map(desc.value, fn f -> generate_field(f) end)
     msg_name = Util.mod_name(ctx, ns ++ [name])
-    Protobuf.Protoc.Template.enum(msg_name, msg_opts(ctx), fields)
+    Protobuf.Protoc.Template.enum(msg_name, msg_opts(ctx, desc), fields, desc)
   end
 
   def generate_field(f) do
     ":#{f.name}, #{f.number}"
   end
 
-  defp msg_opts(%{syntax: syntax}) do
+  defp msg_opts(%{syntax: syntax}, desc) do
     opts = %{syntax: syntax, enum: true}
     str = Util.options_to_str(opts)
     ", " <> str

--- a/lib/protobuf/protoc/generator/enum.ex
+++ b/lib/protobuf/protoc/generator/enum.ex
@@ -16,7 +16,7 @@ defmodule Protobuf.Protoc.Generator.Enum do
     ":#{f.name}, #{f.number}"
   end
 
-  defp msg_opts(%{syntax: syntax}, desc) do
+  defp msg_opts(%{syntax: syntax}, _desc) do
     opts = %{syntax: syntax, enum: true}
     str = Util.options_to_str(opts)
     ", " <> str

--- a/lib/protobuf/protoc/generator/message.ex
+++ b/lib/protobuf/protoc/generator/message.ex
@@ -24,7 +24,8 @@ defmodule Protobuf.Protoc.Generator.Message do
       structs: structs_str(desc),
       typespec: typespec_str(fields, desc.oneof_decl),
       fields: fields,
-      oneofs: oneofs_str(desc.oneof_decl)
+      oneofs: oneofs_str(desc.oneof_decl),
+      desc: desc,
     }
   end
 
@@ -35,7 +36,8 @@ defmodule Protobuf.Protoc.Generator.Message do
       msg_struct[:structs],
       msg_struct[:typespec],
       msg_struct[:oneofs],
-      gen_fields(syntax, msg_struct[:fields])
+      gen_fields(syntax, msg_struct[:fields]),
+      msg_struct[:desc]
     )
   end
 

--- a/lib/protobuf/protoc/generator/message.ex
+++ b/lib/protobuf/protoc/generator/message.ex
@@ -16,6 +16,7 @@ defmodule Protobuf.Protoc.Generator.Message do
   def parse_desc(%{namespace: ns} = ctx, desc) do
     new_ns = ns ++ [Util.trans_name(desc.name)]
     fields = get_fields(ctx, desc)
+    generate_desc = if ctx.gen_descriptors?, do: desc, else: nil
 
     %{
       new_namespace: new_ns,
@@ -25,7 +26,7 @@ defmodule Protobuf.Protoc.Generator.Message do
       typespec: typespec_str(fields, desc.oneof_decl),
       fields: fields,
       oneofs: oneofs_str(desc.oneof_decl),
-      desc: desc,
+      desc: generate_desc
     }
   end
 

--- a/lib/protobuf/protoc/generator/service.ex
+++ b/lib/protobuf/protoc/generator/service.ex
@@ -14,7 +14,7 @@ defmodule Protobuf.Protoc.Generator.Service do
     mod_name = Util.mod_name(ctx, [Util.trans_name(desc.name)])
     name = Util.attach_raw_pkg(desc.name, ctx.package)
     methods = Enum.map(desc.method, fn m -> generate_service_method(ctx, m) end)
-    Protobuf.Protoc.Template.service(mod_name, name, methods)
+    Protobuf.Protoc.Template.service(mod_name, name, methods, desc)
   end
 
   defp generate_service_method(ctx, m) do

--- a/lib/protobuf/protoc/generator/service.ex
+++ b/lib/protobuf/protoc/generator/service.ex
@@ -14,7 +14,8 @@ defmodule Protobuf.Protoc.Generator.Service do
     mod_name = Util.mod_name(ctx, [Util.trans_name(desc.name)])
     name = Util.attach_raw_pkg(desc.name, ctx.package)
     methods = Enum.map(desc.method, fn m -> generate_service_method(ctx, m) end)
-    Protobuf.Protoc.Template.service(mod_name, name, methods, desc)
+    generate_desc = if ctx.gen_descriptors?, do: desc, else: nil
+    Protobuf.Protoc.Template.service(mod_name, name, methods, generate_desc)
   end
 
   defp generate_service_method(ctx, m) do

--- a/lib/protobuf/protoc/template.ex
+++ b/lib/protobuf/protoc/template.ex
@@ -9,10 +9,10 @@ defmodule Protobuf.Protoc.Template do
     :def,
     :message,
     @msg_tmpl,
-    [:name, :options, :struct_fields, :typespec, :oneofs, :fields],
+    [:name, :options, :struct_fields, :typespec, :oneofs, :fields, :desc],
     trim: true
   )
 
-  EEx.function_from_file(:def, :enum, @enum_tmpl, [:name, :options, :fields], trim: true)
-  EEx.function_from_file(:def, :service, @svc_tmpl, [:mod_name, :name, :methods], trim: true)
+  EEx.function_from_file(:def, :enum, @enum_tmpl, [:name, :options, :fields, :desc], trim: true)
+  EEx.function_from_file(:def, :service, @svc_tmpl, [:mod_name, :name, :methods, :desc], trim: true)
 end

--- a/priv/templates/enum.ex.eex
+++ b/priv/templates/enum.ex.eex
@@ -4,6 +4,7 @@ defmodule <%= name %> do
 
   <%= if not is_nil(desc) do %>
   def descriptor do
+    # credo:disable-for-next-line
     <%= desc.__struct__ %>.decode(
       <%= desc.__struct__.encode(desc |> Map.from_struct() |> Enum.filter(fn {_, x} -> x != nil end) |> desc.__struct__.new()) |> inspect(limit: :infinity) %>
     )

--- a/priv/templates/enum.ex.eex
+++ b/priv/templates/enum.ex.eex
@@ -3,8 +3,10 @@ defmodule <%= name %> do
   use Protobuf<%= options %>
 
   def descriptor do
-    <%= desc.__struct__.encode(desc |> Map.from_struct() |> Enum.filter(fn {_, x} -> x != nil end) |> desc.__struct__.new()) |> inspect(limit: :infinity) %>
-    |> <%= desc.__struct__ %>.decode()
+    bin_desc = 
+      <%= desc.__struct__.encode(desc |> Map.from_struct() |> Enum.filter(fn {_, x} -> x != nil end) |> desc.__struct__.new()) |> inspect(limit: :infinity) %>
+
+    <%= desc.__struct__ %>.decode(bin_desc)
   end
 
 <%= Enum.map fields, fn(field) -> %>

--- a/priv/templates/enum.ex.eex
+++ b/priv/templates/enum.ex.eex
@@ -2,6 +2,11 @@ defmodule <%= name %> do
   @moduledoc false
   use Protobuf<%= options %>
 
+  def descriptor do
+    <%= desc.__struct__.encode(desc |> Map.from_struct() |> Enum.filter(fn {_, x} -> x != nil end) |> desc.__struct__.new()) |> inspect(limit: :infinity) %>
+    |> <%= desc.__struct__ %>.decode()
+  end
+
 <%= Enum.map fields, fn(field) -> %>
   field <%= field %>
 <% end %>

--- a/priv/templates/enum.ex.eex
+++ b/priv/templates/enum.ex.eex
@@ -3,10 +3,9 @@ defmodule <%= name %> do
   use Protobuf<%= options %>
 
   def descriptor do
-    bin_desc = 
+    <%= desc.__struct__ %>.decode(
       <%= desc.__struct__.encode(desc |> Map.from_struct() |> Enum.filter(fn {_, x} -> x != nil end) |> desc.__struct__.new()) |> inspect(limit: :infinity) %>
-
-    <%= desc.__struct__ %>.decode(bin_desc)
+    )
   end
 
 <%= Enum.map fields, fn(field) -> %>

--- a/priv/templates/enum.ex.eex
+++ b/priv/templates/enum.ex.eex
@@ -2,11 +2,13 @@ defmodule <%= name %> do
   @moduledoc false
   use Protobuf<%= options %>
 
+  <%= if not is_nil(desc) do %>
   def descriptor do
     <%= desc.__struct__ %>.decode(
       <%= desc.__struct__.encode(desc |> Map.from_struct() |> Enum.filter(fn {_, x} -> x != nil end) |> desc.__struct__.new()) |> inspect(limit: :infinity) %>
     )
   end
+  <% end %>
 
 <%= Enum.map fields, fn(field) -> %>
   field <%= field %>

--- a/priv/templates/message.ex.eex
+++ b/priv/templates/message.ex.eex
@@ -1,9 +1,15 @@
 defmodule <%= name %> do
   @moduledoc false
+
   use Protobuf<%= options %>
 
   <%= typespec %>
   defstruct [<%= struct_fields %>]
+
+  def descriptor do
+    <%= desc.__struct__.encode(desc |> Map.from_struct() |> Enum.filter(fn {_, x} -> x != nil end) |> desc.__struct__.new()) |> inspect(limit: :infinity) %>
+    |> <%= desc.__struct__ %>.decode()
+  end
 
 <%= for v <- oneofs do %>  <%= v %>
 <% end %><%= for f <- fields do %>  field <%= f %>

--- a/priv/templates/message.ex.eex
+++ b/priv/templates/message.ex.eex
@@ -8,6 +8,7 @@ defmodule <%= name %> do
 
   <%= if not is_nil(desc) do %>
   def descriptor do
+    # credo:disable-for-next-line
     <%= desc.__struct__ %>.decode(
       <%= desc.__struct__.encode(desc |> Map.from_struct() |> Enum.filter(fn {_, x} -> x != nil end) |> desc.__struct__.new()) |> inspect(limit: :infinity) %>
     )

--- a/priv/templates/message.ex.eex
+++ b/priv/templates/message.ex.eex
@@ -7,8 +7,10 @@ defmodule <%= name %> do
   defstruct [<%= struct_fields %>]
 
   def descriptor do
-    <%= desc.__struct__.encode(desc |> Map.from_struct() |> Enum.filter(fn {_, x} -> x != nil end) |> desc.__struct__.new()) |> inspect(limit: :infinity) %>
-    |> <%= desc.__struct__ %>.decode()
+    bin_desc =
+      <%= desc.__struct__.encode(desc |> Map.from_struct() |> Enum.filter(fn {_, x} -> x != nil end) |> desc.__struct__.new()) |> inspect(limit: :infinity) %>
+
+    <%= desc.__struct__ %>.decode(bin_desc)
   end
 
 <%= for v <- oneofs do %>  <%= v %>

--- a/priv/templates/message.ex.eex
+++ b/priv/templates/message.ex.eex
@@ -7,6 +7,7 @@ defmodule <%= name %> do
   defstruct [<%= struct_fields %>]
 
   def descriptor do
+    IO.inspect(desc)
     <%= desc.__struct__.encode(desc |> Map.from_struct() |> Enum.filter(fn {_, x} -> x != nil end) |> desc.__struct__.new()) |> inspect(limit: :infinity) %>
     |> <%= desc.__struct__ %>.decode()
   end

--- a/priv/templates/message.ex.eex
+++ b/priv/templates/message.ex.eex
@@ -7,7 +7,6 @@ defmodule <%= name %> do
   defstruct [<%= struct_fields %>]
 
   def descriptor do
-    IO.inspect(desc)
     <%= desc.__struct__.encode(desc |> Map.from_struct() |> Enum.filter(fn {_, x} -> x != nil end) |> desc.__struct__.new()) |> inspect(limit: :infinity) %>
     |> <%= desc.__struct__ %>.decode()
   end

--- a/priv/templates/message.ex.eex
+++ b/priv/templates/message.ex.eex
@@ -7,10 +7,9 @@ defmodule <%= name %> do
   defstruct [<%= struct_fields %>]
 
   def descriptor do
-    bin_desc =
+    <%= desc.__struct__ %>.decode(
       <%= desc.__struct__.encode(desc |> Map.from_struct() |> Enum.filter(fn {_, x} -> x != nil end) |> desc.__struct__.new()) |> inspect(limit: :infinity) %>
-
-    <%= desc.__struct__ %>.decode(bin_desc)
+    )
   end
 
 <%= for v <- oneofs do %>  <%= v %>

--- a/priv/templates/message.ex.eex
+++ b/priv/templates/message.ex.eex
@@ -6,11 +6,13 @@ defmodule <%= name %> do
   <%= typespec %>
   defstruct [<%= struct_fields %>]
 
+  <%= if not is_nil(desc) do %>
   def descriptor do
     <%= desc.__struct__ %>.decode(
       <%= desc.__struct__.encode(desc |> Map.from_struct() |> Enum.filter(fn {_, x} -> x != nil end) |> desc.__struct__.new()) |> inspect(limit: :infinity) %>
     )
   end
+  <% end %>
 
 <%= for v <- oneofs do %>  <%= v %>
 <% end %><%= for f <- fields do %>  field <%= f %>

--- a/priv/templates/service.ex.eex
+++ b/priv/templates/service.ex.eex
@@ -3,10 +3,9 @@ defmodule <%= mod_name %>.Service do
   use GRPC.Service, name: <%= inspect(name) %>
 
   def descriptor do
-    bin_desc
+    <%= desc.__struct__ %>.decode(
       <%= desc.__struct__.encode(desc |> Map.from_struct() |> Enum.filter(fn {_, x} -> x != nil end) |> desc.__struct__.new()) |> inspect(limit: :infinity) %>
-
-    <%= desc.__struct__ %>.decode(bin_desc)
+    )
   end
 
 <%= Enum.map methods, fn(method) -> %>

--- a/priv/templates/service.ex.eex
+++ b/priv/templates/service.ex.eex
@@ -4,6 +4,7 @@ defmodule <%= mod_name %>.Service do
 
   <%= if not is_nil(desc) do %>
   def descriptor do
+    # credo:disable-for-next-line
     <%= desc.__struct__ %>.decode(
       <%= desc.__struct__.encode(desc |> Map.from_struct() |> Enum.filter(fn {_, x} -> x != nil end) |> desc.__struct__.new()) |> inspect(limit: :infinity) %>
     )

--- a/priv/templates/service.ex.eex
+++ b/priv/templates/service.ex.eex
@@ -3,8 +3,10 @@ defmodule <%= mod_name %>.Service do
   use GRPC.Service, name: <%= inspect(name) %>
 
   def descriptor do
-    <%= desc.__struct__.encode(desc |> Map.from_struct() |> Enum.filter(fn {_, x} -> x != nil end) |> desc.__struct__.new()) |> inspect(limit: :infinity) %>
-    |> <%= desc.__struct__ %>.decode()
+    bin_desc
+      <%= desc.__struct__.encode(desc |> Map.from_struct() |> Enum.filter(fn {_, x} -> x != nil end) |> desc.__struct__.new()) |> inspect(limit: :infinity) %>
+
+    <%= desc.__struct__ %>.decode(bin_desc)
   end
 
 <%= Enum.map methods, fn(method) -> %>

--- a/priv/templates/service.ex.eex
+++ b/priv/templates/service.ex.eex
@@ -2,6 +2,11 @@ defmodule <%= mod_name %>.Service do
   @moduledoc false
   use GRPC.Service, name: <%= inspect(name) %>
 
+  def descriptor do
+    <%= desc.__struct__.encode(desc |> Map.from_struct() |> Enum.filter(fn {_, x} -> x != nil end) |> desc.__struct__.new()) |> inspect(limit: :infinity) %>
+    |> <%= desc.__struct__ %>.decode()
+  end
+
 <%= Enum.map methods, fn(method) -> %>
   rpc <%= method %>
 <% end %>

--- a/priv/templates/service.ex.eex
+++ b/priv/templates/service.ex.eex
@@ -2,11 +2,13 @@ defmodule <%= mod_name %>.Service do
   @moduledoc false
   use GRPC.Service, name: <%= inspect(name) %>
 
+  <%= if not is_nil(desc) do %>
   def descriptor do
     <%= desc.__struct__ %>.decode(
       <%= desc.__struct__.encode(desc |> Map.from_struct() |> Enum.filter(fn {_, x} -> x != nil end) |> desc.__struct__.new()) |> inspect(limit: :infinity) %>
     )
   end
+  <% end %>
 
 <%= Enum.map methods, fn(method) -> %>
   rpc <%= method %>

--- a/test/protobuf/protoc/cli_test.exs
+++ b/test/protobuf/protoc/cli_test.exs
@@ -10,8 +10,8 @@ defmodule Protobuf.Protoc.CLITest do
 
   test "parse_params/2 parse plugins" do
     ctx = %Context{}
-    ctx = parse_params(ctx, "plugins=grpc")
-    assert ctx == %Context{plugins: ["grpc"]}
+    ctx = parse_params(ctx, "plugins=grpc,gen_descriptors=true")
+    assert ctx == %Context{plugins: ["grpc"], gen_descriptors?: true}
   end
 
   test "find_types/2 returns multiple files" do

--- a/test/protobuf/protoc/generator/enum_test.exs
+++ b/test/protobuf/protoc/generator/enum_test.exs
@@ -11,8 +11,8 @@ defmodule Protobuf.Protoc.Generator.EnumTest do
       name: "EnumFoo",
       options: nil,
       value: [
-        %Google.Protobuf.EnumValueDescriptorProto{name: "A", number: 0},
-        %Google.Protobuf.EnumValueDescriptorProto{name: "B", number: 1}
+        Google.Protobuf.EnumValueDescriptorProto.new(name: "A", number: 0),
+        Google.Protobuf.EnumValueDescriptorProto.new(name: "B", number: 1)
       ]
     }
 

--- a/test/protobuf/protoc/generator/message_test.exs
+++ b/test/protobuf/protoc/generator/message_test.exs
@@ -143,7 +143,7 @@ defmodule Protobuf.Protoc.Generator.MessageTest do
             number: 1,
             type: :TYPE_INT32,
             label: :LABEL_OPTIONAL,
-            options: %Google.Protobuf.FieldOptions{packed: true}
+            options: Google.Protobuf.FieldOptions.new(packed: true)
           )
         ]
       )
@@ -164,7 +164,7 @@ defmodule Protobuf.Protoc.Generator.MessageTest do
             number: 1,
             type: :TYPE_INT32,
             label: :LABEL_OPTIONAL,
-            options: %Google.Protobuf.FieldOptions{deprecated: true}
+            options: Google.Protobuf.FieldOptions.new(deprecated: true)
           )
         ]
       )
@@ -362,8 +362,8 @@ defmodule Protobuf.Protoc.Generator.MessageTest do
               Google.Protobuf.EnumDescriptorProto.new(
                 name: "EnumFoo",
                 value: [
-                  %Google.Protobuf.EnumValueDescriptorProto{name: "a", number: 0},
-                  %Google.Protobuf.EnumValueDescriptorProto{name: "b", number: 1}
+                  Google.Protobuf.EnumValueDescriptorProto.new(name: "a", number: 0),
+                  Google.Protobuf.EnumValueDescriptorProto.new(name: "b", number: 1)
                 ]
               )
             ],

--- a/test/protobuf/protoc/generator/service_test.exs
+++ b/test/protobuf/protoc/generator/service_test.exs
@@ -23,30 +23,30 @@ defmodule Protobuf.Protoc.Generator.ServiceTest do
     desc = %Google.Protobuf.ServiceDescriptorProto{
       name: "ServiceFoo",
       method: [
-        %Google.Protobuf.MethodDescriptorProto{
+        Google.Protobuf.MethodDescriptorProto.new(
           name: "MethodA",
           input_type: ".foo.Input0",
           output_type: ".foo.Output0"
-        },
-        %Google.Protobuf.MethodDescriptorProto{
+        ),
+        Google.Protobuf.MethodDescriptorProto.new(
           name: "MethodB",
           input_type: ".foo.Input1",
           output_type: ".foo.Output1",
           client_streaming: true
-        },
-        %Google.Protobuf.MethodDescriptorProto{
+        ),
+        Google.Protobuf.MethodDescriptorProto.new(
           name: "MethodC",
           input_type: ".foo.Input2",
           output_type: ".foo.Output2",
           server_streaming: true
-        },
-        %Google.Protobuf.MethodDescriptorProto{
+        ),
+        Google.Protobuf.MethodDescriptorProto.new(
           name: "MethodD",
           input_type: ".foo.Input3",
           output_type: ".foo.Output3",
           client_streaming: true,
           server_streaming: true
-        }
+        )
       ]
     }
 

--- a/test/protobuf/protoc/proto_gen/test.pb.ex
+++ b/test/protobuf/protoc/proto_gen/test.pb.ex
@@ -1,5 +1,6 @@
 defmodule My.Test.Request do
   @moduledoc false
+
   use Protobuf, syntax: :proto2
 
   @type t :: %__MODULE__{
@@ -25,6 +26,40 @@ defmodule My.Test.Request do
     :get_key
   ]
 
+  def descriptor do
+    <<10, 7, 82, 101, 113, 117, 101, 115, 116, 18, 16, 10, 3, 107, 101, 121, 24, 1, 32, 3, 40, 3,
+      82, 3, 107, 101, 121, 18, 40, 10, 3, 104, 117, 101, 24, 3, 32, 1, 40, 14, 50, 22, 46, 109,
+      121, 46, 116, 101, 115, 116, 46, 82, 101, 113, 117, 101, 115, 116, 46, 67, 111, 108, 111,
+      114, 82, 3, 104, 117, 101, 18, 42, 10, 3, 104, 97, 116, 24, 4, 32, 1, 40, 14, 50, 16, 46,
+      109, 121, 46, 116, 101, 115, 116, 46, 72, 97, 116, 84, 121, 112, 101, 58, 6, 70, 69, 68, 79,
+      82, 65, 82, 3, 104, 97, 116, 18, 31, 10, 8, 100, 101, 97, 100, 108, 105, 110, 101, 24, 7,
+      32, 1, 40, 2, 58, 3, 105, 110, 102, 82, 8, 100, 101, 97, 100, 108, 105, 110, 101, 18, 56,
+      10, 9, 115, 111, 109, 101, 103, 114, 111, 117, 112, 24, 8, 32, 1, 40, 10, 50, 26, 46, 109,
+      121, 46, 116, 101, 115, 116, 46, 82, 101, 113, 117, 101, 115, 116, 46, 83, 111, 109, 101,
+      71, 114, 111, 117, 112, 82, 9, 115, 111, 109, 101, 103, 114, 111, 117, 112, 18, 68, 10, 12,
+      110, 97, 109, 101, 95, 109, 97, 112, 112, 105, 110, 103, 24, 14, 32, 3, 40, 11, 50, 33, 46,
+      109, 121, 46, 116, 101, 115, 116, 46, 82, 101, 113, 117, 101, 115, 116, 46, 78, 97, 109,
+      101, 77, 97, 112, 112, 105, 110, 103, 69, 110, 116, 114, 121, 82, 11, 110, 97, 109, 101, 77,
+      97, 112, 112, 105, 110, 103, 18, 65, 10, 11, 109, 115, 103, 95, 109, 97, 112, 112, 105, 110,
+      103, 24, 15, 32, 3, 40, 11, 50, 32, 46, 109, 121, 46, 116, 101, 115, 116, 46, 82, 101, 113,
+      117, 101, 115, 116, 46, 77, 115, 103, 77, 97, 112, 112, 105, 110, 103, 69, 110, 116, 114,
+      121, 82, 10, 109, 115, 103, 77, 97, 112, 112, 105, 110, 103, 18, 20, 10, 5, 114, 101, 115,
+      101, 116, 24, 12, 32, 1, 40, 5, 82, 5, 114, 101, 115, 101, 116, 18, 23, 10, 7, 103, 101,
+      116, 95, 107, 101, 121, 24, 16, 32, 1, 40, 9, 82, 6, 103, 101, 116, 75, 101, 121, 26, 44,
+      10, 9, 83, 111, 109, 101, 71, 114, 111, 117, 112, 18, 31, 10, 11, 103, 114, 111, 117, 112,
+      95, 102, 105, 101, 108, 100, 24, 9, 32, 1, 40, 5, 82, 10, 103, 114, 111, 117, 112, 70, 105,
+      101, 108, 100, 26, 68, 10, 16, 78, 97, 109, 101, 77, 97, 112, 112, 105, 110, 103, 69, 110,
+      116, 114, 121, 18, 16, 10, 3, 107, 101, 121, 24, 1, 32, 1, 40, 5, 82, 3, 107, 101, 121, 18,
+      20, 10, 5, 118, 97, 108, 117, 101, 24, 2, 32, 1, 40, 9, 82, 5, 118, 97, 108, 117, 101, 58,
+      8, 8, 0, 16, 0, 24, 0, 56, 1, 26, 83, 10, 15, 77, 115, 103, 77, 97, 112, 112, 105, 110, 103,
+      69, 110, 116, 114, 121, 18, 16, 10, 3, 107, 101, 121, 24, 1, 32, 1, 40, 18, 82, 3, 107, 101,
+      121, 18, 36, 10, 5, 118, 97, 108, 117, 101, 24, 2, 32, 1, 40, 11, 50, 14, 46, 109, 121, 46,
+      116, 101, 115, 116, 46, 82, 101, 112, 108, 121, 82, 5, 118, 97, 108, 117, 101, 58, 8, 8, 0,
+      16, 0, 24, 0, 56, 1, 34, 37, 10, 5, 67, 111, 108, 111, 114, 18, 7, 10, 3, 82, 69, 68, 16, 0,
+      18, 9, 10, 5, 71, 82, 69, 69, 78, 16, 1, 18, 8, 10, 4, 66, 76, 85, 69, 16, 2>>
+    |> Elixir.Google.Protobuf.DescriptorProto.decode()
+  end
+
   field :key, 1, repeated: true, type: :int64
   field :hue, 3, optional: true, type: My.Test.Request.Color, enum: true
   field :hat, 4, optional: true, type: My.Test.HatType, default: :FEDORA, enum: true
@@ -38,6 +73,7 @@ end
 
 defmodule My.Test.Request.SomeGroup do
   @moduledoc false
+
   use Protobuf, syntax: :proto2
 
   @type t :: %__MODULE__{
@@ -45,11 +81,19 @@ defmodule My.Test.Request.SomeGroup do
         }
   defstruct [:group_field]
 
+  def descriptor do
+    <<10, 9, 83, 111, 109, 101, 71, 114, 111, 117, 112, 18, 31, 10, 11, 103, 114, 111, 117, 112,
+      95, 102, 105, 101, 108, 100, 24, 9, 32, 1, 40, 5, 82, 10, 103, 114, 111, 117, 112, 70, 105,
+      101, 108, 100>>
+    |> Elixir.Google.Protobuf.DescriptorProto.decode()
+  end
+
   field :group_field, 9, optional: true, type: :int32
 end
 
 defmodule My.Test.Request.NameMappingEntry do
   @moduledoc false
+
   use Protobuf, map: true, syntax: :proto2
 
   @type t :: %__MODULE__{
@@ -58,12 +102,21 @@ defmodule My.Test.Request.NameMappingEntry do
         }
   defstruct [:key, :value]
 
+  def descriptor do
+    <<10, 16, 78, 97, 109, 101, 77, 97, 112, 112, 105, 110, 103, 69, 110, 116, 114, 121, 18, 16,
+      10, 3, 107, 101, 121, 24, 1, 32, 1, 40, 5, 82, 3, 107, 101, 121, 18, 20, 10, 5, 118, 97,
+      108, 117, 101, 24, 2, 32, 1, 40, 9, 82, 5, 118, 97, 108, 117, 101, 58, 8, 8, 0, 16, 0, 24,
+      0, 56, 1>>
+    |> Elixir.Google.Protobuf.DescriptorProto.decode()
+  end
+
   field :key, 1, optional: true, type: :int32
   field :value, 2, optional: true, type: :string
 end
 
 defmodule My.Test.Request.MsgMappingEntry do
   @moduledoc false
+
   use Protobuf, map: true, syntax: :proto2
 
   @type t :: %__MODULE__{
@@ -71,6 +124,14 @@ defmodule My.Test.Request.MsgMappingEntry do
           value: My.Test.Reply.t() | nil
         }
   defstruct [:key, :value]
+
+  def descriptor do
+    <<10, 15, 77, 115, 103, 77, 97, 112, 112, 105, 110, 103, 69, 110, 116, 114, 121, 18, 16, 10,
+      3, 107, 101, 121, 24, 1, 32, 1, 40, 18, 82, 3, 107, 101, 121, 18, 36, 10, 5, 118, 97, 108,
+      117, 101, 24, 2, 32, 1, 40, 11, 50, 14, 46, 109, 121, 46, 116, 101, 115, 116, 46, 82, 101,
+      112, 108, 121, 82, 5, 118, 97, 108, 117, 101, 58, 8, 8, 0, 16, 0, 24, 0, 56, 1>>
+    |> Elixir.Google.Protobuf.DescriptorProto.decode()
+  end
 
   field :key, 1, optional: true, type: :sint64
   field :value, 2, optional: true, type: My.Test.Reply
@@ -80,6 +141,12 @@ defmodule My.Test.Request.Color do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
 
+  def descriptor do
+    <<10, 5, 67, 111, 108, 111, 114, 18, 7, 10, 3, 82, 69, 68, 16, 0, 18, 9, 10, 5, 71, 82, 69,
+      69, 78, 16, 1, 18, 8, 10, 4, 66, 76, 85, 69, 16, 2>>
+    |> Elixir.Google.Protobuf.EnumDescriptorProto.decode()
+  end
+
   field :RED, 0
   field :GREEN, 1
   field :BLUE, 2
@@ -87,6 +154,7 @@ end
 
 defmodule My.Test.Reply do
   @moduledoc false
+
   use Protobuf, syntax: :proto2
 
   @type t :: %__MODULE__{
@@ -95,12 +163,31 @@ defmodule My.Test.Reply do
         }
   defstruct [:found, :compact_keys]
 
+  def descriptor do
+    <<10, 5, 82, 101, 112, 108, 121, 18, 42, 10, 5, 102, 111, 117, 110, 100, 24, 1, 32, 3, 40, 11,
+      50, 20, 46, 109, 121, 46, 116, 101, 115, 116, 46, 82, 101, 112, 108, 121, 46, 69, 110, 116,
+      114, 121, 82, 5, 102, 111, 117, 110, 100, 18, 47, 10, 12, 99, 111, 109, 112, 97, 99, 116,
+      95, 107, 101, 121, 115, 24, 2, 32, 3, 40, 5, 66, 12, 8, 0, 16, 1, 24, 0, 40, 0, 48, 0, 80,
+      0, 82, 11, 99, 111, 109, 112, 97, 99, 116, 75, 101, 121, 115, 26, 176, 1, 10, 5, 69, 110,
+      116, 114, 121, 18, 68, 10, 31, 107, 101, 121, 95, 116, 104, 97, 116, 95, 110, 101, 101, 100,
+      115, 95, 49, 50, 51, 52, 99, 97, 109, 101, 108, 95, 67, 97, 115, 73, 110, 103, 24, 1, 32, 2,
+      40, 3, 82, 27, 107, 101, 121, 84, 104, 97, 116, 78, 101, 101, 100, 115, 49, 50, 51, 52, 99,
+      97, 109, 101, 108, 67, 97, 115, 73, 110, 103, 18, 23, 10, 5, 118, 97, 108, 117, 101, 24, 2,
+      32, 1, 40, 3, 58, 1, 55, 82, 5, 118, 97, 108, 117, 101, 18, 38, 10, 16, 95, 109, 121, 95,
+      102, 105, 101, 108, 100, 95, 110, 97, 109, 101, 95, 50, 24, 3, 32, 1, 40, 3, 82, 12, 77,
+      121, 70, 105, 101, 108, 100, 78, 97, 109, 101, 50, 34, 32, 10, 4, 71, 97, 109, 101, 18, 12,
+      10, 8, 70, 79, 79, 84, 66, 65, 76, 76, 16, 1, 18, 10, 10, 6, 84, 69, 78, 78, 73, 83, 16, 2,
+      42, 8, 8, 100, 16, 128, 128, 128, 128, 2>>
+    |> Elixir.Google.Protobuf.DescriptorProto.decode()
+  end
+
   field :found, 1, repeated: true, type: My.Test.Reply.Entry
   field :compact_keys, 2, repeated: true, type: :int32, packed: true
 end
 
 defmodule My.Test.Reply.Entry do
   @moduledoc false
+
   use Protobuf, syntax: :proto2
 
   @type t :: %__MODULE__{
@@ -109,6 +196,19 @@ defmodule My.Test.Reply.Entry do
           _my_field_name_2: integer
         }
   defstruct [:key_that_needs_1234camel_CasIng, :value, :_my_field_name_2]
+
+  def descriptor do
+    <<10, 5, 69, 110, 116, 114, 121, 18, 68, 10, 31, 107, 101, 121, 95, 116, 104, 97, 116, 95,
+      110, 101, 101, 100, 115, 95, 49, 50, 51, 52, 99, 97, 109, 101, 108, 95, 67, 97, 115, 73,
+      110, 103, 24, 1, 32, 2, 40, 3, 82, 27, 107, 101, 121, 84, 104, 97, 116, 78, 101, 101, 100,
+      115, 49, 50, 51, 52, 99, 97, 109, 101, 108, 67, 97, 115, 73, 110, 103, 18, 23, 10, 5, 118,
+      97, 108, 117, 101, 24, 2, 32, 1, 40, 3, 58, 1, 55, 82, 5, 118, 97, 108, 117, 101, 18, 38,
+      10, 16, 95, 109, 121, 95, 102, 105, 101, 108, 100, 95, 110, 97, 109, 101, 95, 50, 24, 3, 32,
+      1, 40, 3, 82, 12, 77, 121, 70, 105, 101, 108, 100, 78, 97, 109, 101, 50, 34, 32, 10, 4, 71,
+      97, 109, 101, 18, 12, 10, 8, 70, 79, 79, 84, 66, 65, 76, 76, 16, 1, 18, 10, 10, 6, 84, 69,
+      78, 78, 73, 83, 16, 2>>
+    |> Elixir.Google.Protobuf.DescriptorProto.decode()
+  end
 
   field :key_that_needs_1234camel_CasIng, 1, required: true, type: :int64
   field :value, 2, optional: true, type: :int64, default: 7
@@ -119,12 +219,19 @@ defmodule My.Test.Reply.Entry.Game do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
 
+  def descriptor do
+    <<10, 4, 71, 97, 109, 101, 18, 12, 10, 8, 70, 79, 79, 84, 66, 65, 76, 76, 16, 1, 18, 10, 10,
+      6, 84, 69, 78, 78, 73, 83, 16, 2>>
+    |> Elixir.Google.Protobuf.EnumDescriptorProto.decode()
+  end
+
   field :FOOTBALL, 1
   field :TENNIS, 2
 end
 
 defmodule My.Test.OtherBase do
   @moduledoc false
+
   use Protobuf, syntax: :proto2
 
   @type t :: %__MODULE__{
@@ -132,19 +239,41 @@ defmodule My.Test.OtherBase do
         }
   defstruct [:name]
 
+  def descriptor do
+    <<10, 9, 79, 116, 104, 101, 114, 66, 97, 115, 101, 18, 18, 10, 4, 110, 97, 109, 101, 24, 1,
+      32, 1, 40, 9, 82, 4, 110, 97, 109, 101, 42, 8, 8, 100, 16, 128, 128, 128, 128, 2>>
+    |> Elixir.Google.Protobuf.DescriptorProto.decode()
+  end
+
   field :name, 1, optional: true, type: :string
 end
 
 defmodule My.Test.ReplyExtensions do
   @moduledoc false
+
   use Protobuf, syntax: :proto2
 
   @type t :: %__MODULE__{}
   defstruct []
+
+  def descriptor do
+    <<10, 15, 82, 101, 112, 108, 121, 69, 120, 116, 101, 110, 115, 105, 111, 110, 115, 50, 34, 10,
+      4, 116, 105, 109, 101, 18, 14, 46, 109, 121, 46, 116, 101, 115, 116, 46, 82, 101, 112, 108,
+      121, 24, 101, 32, 1, 40, 1, 82, 4, 116, 105, 109, 101, 50, 64, 10, 6, 99, 97, 114, 114, 111,
+      116, 18, 14, 46, 109, 121, 46, 116, 101, 115, 116, 46, 82, 101, 112, 108, 121, 24, 105, 32,
+      1, 40, 11, 50, 24, 46, 109, 121, 46, 116, 101, 115, 116, 46, 82, 101, 112, 108, 121, 69,
+      120, 116, 101, 110, 115, 105, 111, 110, 115, 82, 6, 99, 97, 114, 114, 111, 116, 50, 66, 10,
+      5, 100, 111, 110, 117, 116, 18, 18, 46, 109, 121, 46, 116, 101, 115, 116, 46, 79, 116, 104,
+      101, 114, 66, 97, 115, 101, 24, 101, 32, 1, 40, 11, 50, 24, 46, 109, 121, 46, 116, 101, 115,
+      116, 46, 82, 101, 112, 108, 121, 69, 120, 116, 101, 110, 115, 105, 111, 110, 115, 82, 5,
+      100, 111, 110, 117, 116>>
+    |> Elixir.Google.Protobuf.DescriptorProto.decode()
+  end
 end
 
 defmodule My.Test.OtherReplyExtensions do
   @moduledoc false
+
   use Protobuf, syntax: :proto2
 
   @type t :: %__MODULE__{
@@ -152,19 +281,33 @@ defmodule My.Test.OtherReplyExtensions do
         }
   defstruct [:key]
 
+  def descriptor do
+    <<10, 20, 79, 116, 104, 101, 114, 82, 101, 112, 108, 121, 69, 120, 116, 101, 110, 115, 105,
+      111, 110, 115, 18, 16, 10, 3, 107, 101, 121, 24, 1, 32, 1, 40, 5, 82, 3, 107, 101, 121>>
+    |> Elixir.Google.Protobuf.DescriptorProto.decode()
+  end
+
   field :key, 1, optional: true, type: :int32
 end
 
 defmodule My.Test.OldReply do
   @moduledoc false
+
   use Protobuf, syntax: :proto2
 
   @type t :: %__MODULE__{}
   defstruct []
+
+  def descriptor do
+    <<10, 8, 79, 108, 100, 82, 101, 112, 108, 121, 42, 8, 8, 100, 16, 255, 255, 255, 255, 7, 58,
+      6, 8, 1, 16, 0, 24, 0>>
+    |> Elixir.Google.Protobuf.DescriptorProto.decode()
+  end
 end
 
 defmodule My.Test.Communique do
   @moduledoc false
+
   use Protobuf, syntax: :proto2
 
   @type t :: %__MODULE__{
@@ -172,6 +315,29 @@ defmodule My.Test.Communique do
           make_me_cry: boolean
         }
   defstruct [:union, :make_me_cry]
+
+  def descriptor do
+    <<10, 10, 67, 111, 109, 109, 117, 110, 105, 113, 117, 101, 18, 30, 10, 11, 109, 97, 107, 101,
+      95, 109, 101, 95, 99, 114, 121, 24, 1, 32, 1, 40, 8, 82, 9, 109, 97, 107, 101, 77, 101, 67,
+      114, 121, 18, 24, 10, 6, 110, 117, 109, 98, 101, 114, 24, 5, 32, 1, 40, 5, 72, 0, 82, 6,
+      110, 117, 109, 98, 101, 114, 18, 20, 10, 4, 110, 97, 109, 101, 24, 6, 32, 1, 40, 9, 72, 0,
+      82, 4, 110, 97, 109, 101, 18, 20, 10, 4, 100, 97, 116, 97, 24, 7, 32, 1, 40, 12, 72, 0, 82,
+      4, 100, 97, 116, 97, 18, 23, 10, 6, 116, 101, 109, 112, 95, 99, 24, 8, 32, 1, 40, 1, 72, 0,
+      82, 5, 116, 101, 109, 112, 67, 18, 24, 10, 6, 104, 101, 105, 103, 104, 116, 24, 9, 32, 1,
+      40, 2, 72, 0, 82, 6, 104, 101, 105, 103, 104, 116, 18, 37, 10, 5, 116, 111, 100, 97, 121,
+      24, 10, 32, 1, 40, 14, 50, 13, 46, 109, 121, 46, 116, 101, 115, 116, 46, 68, 97, 121, 115,
+      72, 0, 82, 5, 116, 111, 100, 97, 121, 18, 22, 10, 5, 109, 97, 121, 98, 101, 24, 11, 32, 1,
+      40, 8, 72, 0, 82, 5, 109, 97, 121, 98, 101, 18, 22, 10, 5, 100, 101, 108, 116, 97, 24, 12,
+      32, 1, 40, 17, 72, 0, 82, 5, 100, 101, 108, 116, 97, 18, 34, 10, 3, 109, 115, 103, 24, 13,
+      32, 1, 40, 11, 50, 14, 46, 109, 121, 46, 116, 101, 115, 116, 46, 82, 101, 112, 108, 121, 72,
+      0, 82, 3, 109, 115, 103, 18, 61, 10, 9, 115, 111, 109, 101, 103, 114, 111, 117, 112, 24, 14,
+      32, 1, 40, 10, 50, 29, 46, 109, 121, 46, 116, 101, 115, 116, 46, 67, 111, 109, 109, 117,
+      110, 105, 113, 117, 101, 46, 83, 111, 109, 101, 71, 114, 111, 117, 112, 72, 0, 82, 9, 115,
+      111, 109, 101, 103, 114, 111, 117, 112, 26, 35, 10, 9, 83, 111, 109, 101, 71, 114, 111, 117,
+      112, 18, 22, 10, 6, 109, 101, 109, 98, 101, 114, 24, 15, 32, 1, 40, 9, 82, 6, 109, 101, 109,
+      98, 101, 114, 26, 7, 10, 5, 68, 101, 108, 116, 97, 66, 7, 10, 5, 117, 110, 105, 111, 110>>
+    |> Elixir.Google.Protobuf.DescriptorProto.decode()
+  end
 
   oneof :union, 0
   field :make_me_cry, 1, optional: true, type: :bool
@@ -189,6 +355,7 @@ end
 
 defmodule My.Test.Communique.SomeGroup do
   @moduledoc false
+
   use Protobuf, syntax: :proto2
 
   @type t :: %__MODULE__{
@@ -196,20 +363,37 @@ defmodule My.Test.Communique.SomeGroup do
         }
   defstruct [:member]
 
+  def descriptor do
+    <<10, 9, 83, 111, 109, 101, 71, 114, 111, 117, 112, 18, 22, 10, 6, 109, 101, 109, 98, 101,
+      114, 24, 15, 32, 1, 40, 9, 82, 6, 109, 101, 109, 98, 101, 114>>
+    |> Elixir.Google.Protobuf.DescriptorProto.decode()
+  end
+
   field :member, 15, optional: true, type: :string
 end
 
 defmodule My.Test.Communique.Delta do
   @moduledoc false
+
   use Protobuf, syntax: :proto2
 
   @type t :: %__MODULE__{}
   defstruct []
+
+  def descriptor do
+    <<10, 5, 68, 101, 108, 116, 97>> |> Elixir.Google.Protobuf.DescriptorProto.decode()
+  end
 end
 
 defmodule My.Test.HatType do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
+
+  def descriptor do
+    <<10, 7, 72, 97, 116, 84, 121, 112, 101, 18, 10, 10, 6, 70, 69, 68, 79, 82, 65, 16, 1, 18, 7,
+      10, 3, 70, 69, 90, 16, 2>>
+    |> Elixir.Google.Protobuf.EnumDescriptorProto.decode()
+  end
 
   field :FEDORA, 1
   field :FEZ, 2
@@ -218,6 +402,13 @@ end
 defmodule My.Test.Days do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
+
+  def descriptor do
+    <<10, 4, 68, 97, 121, 115, 18, 10, 10, 6, 77, 79, 78, 68, 65, 89, 16, 1, 18, 11, 10, 7, 84,
+      85, 69, 83, 68, 65, 89, 16, 2, 18, 9, 10, 5, 76, 85, 78, 68, 73, 16, 1, 26, 4, 16, 1, 24,
+      0>>
+    |> Elixir.Google.Protobuf.EnumDescriptorProto.decode()
+  end
 
   field :MONDAY, 1
   field :TUESDAY, 2


### PR DESCRIPTION
There is a great deal of information in the descriptors that unfortunately is lost with the current approach.

Most protubuf libraries provide access to the raw descriptors, this PR brings this lib inline with that philosophy by
adding the encoded descriptor to the generated modules and exposing them via a `descriptor` function.