### PR TITLE
Fix oneof enum encoding

### DIFF
--- a/lib/protobuf/encoder.ex
+++ b/lib/protobuf/encoder.ex
@@ -40,8 +40,10 @@ defmodule Protobuf.Encoder do
           syntax == :proto2 && ((val == nil && prop.optional?) || val == [] || val == %{}) ->
             acc
 
-          syntax == :proto3 && ((empty_val?(val) && !oneof) || (is_enum && is_enum_default(type, val)) ||
-                                (oneof && is_nil(val))) ->
+          syntax == :proto3 && ((empty_val?(val) && !oneof) ||
+                               (empty_val?(val) && oneof && is_enum) ||
+                               (is_enum && is_enum_default(type, val)) ||
+                               (oneof && is_nil(val))) ->
             acc
 
           true ->

--- a/test/protobuf/encoder_test.exs
+++ b/test/protobuf/encoder_test.exs
@@ -129,9 +129,9 @@ defmodule Protobuf.EncoderTest do
   end
 
   test "encodes oneof fields" do
-    msg = %TestMsg.Oneof{first: {:a, 42}, second: {:d, "abc"}, other: "other"}
+    msg = TestMsg.Oneof.new(%{first: {:a, 42}, second: {:d, "abc"}, other: "other"})
     assert Encoder.encode(msg) == <<8, 42, 34, 3, 97, 98, 99, 42, 5, 111, 116, 104, 101, 114>>
-    msg = %TestMsg.Oneof{first: {:b, "abc"}, second: {:c, 123}, other: "other"}
+    msg = TestMsg.Oneof.new(%{first: {:b, "abc"}, second: {:c, 123}, other: "other"})
     assert Encoder.encode(msg) == <<18, 3, 97, 98, 99, 24, 123, 42, 5, 111, 116, 104, 101, 114>>
   end
 
@@ -142,8 +142,11 @@ defmodule Protobuf.EncoderTest do
     assert Encoder.encode(msg) == <<18, 0, 24, 0>>
 
     msg = TestMsg.OneofProto3.new(first: {:a, 0}, second: {:d, ""})
+    IO.inspect(msg)
     assert Encoder.encode(msg) == <<8, 0, 34, 0>>
+    assert TestMsg.OneofProto3.encode(msg) == <<8, 0, 34, 0>>
     msg = TestMsg.OneofProto3.new(first: {:b, ""}, second: {:c, 0})
     assert Encoder.encode(msg) == <<18, 0, 24, 0>>
+    assert TestMsg.OneofProto3.encode(msg) == <<18, 0, 24, 0>>
   end
 end

--- a/test/support/test_msg.ex
+++ b/test/support/test_msg.ex
@@ -97,6 +97,7 @@ defmodule TestMsg do
     oneof :second, 1
     field :a, 1, optional: true, type: :int32, oneof: 0
     field :b, 2, optional: true, type: :string, oneof: 0
+    field :e, 6, type: EnumFoo, enum: true, oneof: 0
     field :c, 3, optional: true, type: :int32, oneof: 1
     field :d, 4, optional: true, type: :string, oneof: 1
     field :other, 5, optional: true, type: :string


### PR DESCRIPTION
When an enum is included as part of a oneof, encoding and `__default_struct__` do not work properly.

Encode breaks with a raise, and `__default_struct__` includes a value for the enum.