### PR TITLE
Add type_url/0 to Protobuf generated modules

### DIFF
--- a/lib/protobuf.ex
+++ b/lib/protobuf.ex
@@ -1,5 +1,17 @@
 defmodule Protobuf do
   defmacro __using__(opts) do
+    path = __CALLER__.module
+      |> Module.split()
+      |> Enum.reverse()
+      |> Enum.with_index()
+      |> Enum.map(fn
+        {item, index} when index > 0 -> String.downcase(item)
+        {item, _} -> item
+      end)
+      |> Enum.reverse()
+      |> Enum.join(".")
+    type_url = "type.googleapis.com/" <> path
+
     quote do
       import Protobuf.DSL, only: [field: 3, field: 2, oneof: 2]
       Module.register_attribute(__MODULE__, :fields, accumulate: true)
@@ -15,6 +27,10 @@ defmodule Protobuf do
 
       def new(attrs) do
         Protobuf.Builder.new(__MODULE__, attrs)
+      end
+
+      def type_url() do
+        unquote(type_url)
       end
     end
   end

--- a/lib/protobuf.ex
+++ b/lib/protobuf.ex
@@ -1,6 +1,6 @@
 defmodule Protobuf do
   defmacro __using__(opts) do
-    path = __CALLER__.module
+    type_path = __CALLER__.module
       |> Module.split()
       |> Enum.reverse()
       |> Enum.with_index()
@@ -10,7 +10,6 @@ defmodule Protobuf do
       end)
       |> Enum.reverse()
       |> Enum.join(".")
-    type_url = "type.googleapis.com/" <> path
 
     quote do
       import Protobuf.DSL, only: [field: 3, field: 2, oneof: 2]
@@ -30,8 +29,14 @@ defmodule Protobuf do
       end
 
       def type_url() do
-        unquote(type_url)
+        Path.join(type_fqdn(), unquote(type_path))
       end
+
+      def type_fqdn() do
+        "type.googleapis.com"
+      end
+
+      defoverridable(type_fqdn: 0)
     end
   end
 


### PR DESCRIPTION
This is to support packing and unpacking `google.protobuf.Any` messages, as is being proposed in a separate PR in [tony612/google-protos](https://github.com/tony612/google-protos).

This compiles the type url as a static value exposed through a `type_url/0` functions in each module generated by the protobuf elixir compiler.