### PR TITLE
Add deprecated to field props

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,14 @@ $ protoc --elixir_out=./lib --plugin=./protoc-gen-elixir *.proto
 $ protoc -I protos --elixir_out=./lib protos/hello.proto
 ```
 
+## Tests
+
+Before you can run the test suite, you must install `eqc_gen`:
+
+```
+$ mix eqc.install --mini
+```
+
 ## Sponsors
 
 This project is being sponsored by [Tubi](https://tubitv.com/). Thank you!

--- a/lib/protobuf/dsl.ex
+++ b/lib/protobuf/dsl.ex
@@ -154,6 +154,7 @@ defmodule Protobuf.DSL do
       |> cal_embedded()
       |> cal_packed(syntax)
       |> cal_repeated(opts_map)
+      |> cal_deprecated()
 
     struct(props, parts)
     |> cal_encoded_fnum()
@@ -254,6 +255,9 @@ defmodule Protobuf.DSL do
   defp cal_repeated(_props, %{repeated: true, oneof: true}), do:
     raise ":oneof can't be used with repeated"
   defp cal_repeated(props, _), do: props
+
+  defp cal_deprecated(%{deprecated: true} = props), do: Map.put(props, :deprecated?, true)
+  defp cal_deprecated(props), do: props
 
   defp cal_encoded_fnum(%{fnum: fnum, packed?: true} = props) do
     encoded_fnum = Protobuf.Encoder.encode_fnum(fnum, Protobuf.Encoder.wire_type(:bytes))

--- a/lib/protobuf/field_props.ex
+++ b/lib/protobuf/field_props.ex
@@ -14,6 +14,7 @@ defmodule Protobuf.FieldProps do
           embedded?: boolean,
           packed?: boolean,
           map?: boolean,
+          deprecated?: boolean,
           encoded_fnum: iodata
         }
   defstruct fnum: nil,
@@ -30,5 +31,6 @@ defmodule Protobuf.FieldProps do
             embedded?: false,
             packed?: nil,
             map?: false,
+            deprecated?: false,
             encoded_fnum: nil
 end

--- a/test/protobuf/dsl_test.exs
+++ b/test/protobuf/dsl_test.exs
@@ -23,7 +23,7 @@ defmodule Protobuf.DSLTest do
     msg_props = Foo.__message_props__()
 
     tags_map =
-      Enum.reduce([1, 2, 3] ++ Enum.to_list(5..16), %{}, fn i, acc -> Map.put(acc, i, i) end)
+      Enum.reduce([1, 2, 3] ++ Enum.to_list(5..17), %{}, fn i, acc -> Map.put(acc, i, i) end)
 
     assert tags_map == msg_props.tags_map
     field_props = msg_props.field_props
@@ -64,7 +64,7 @@ defmodule Protobuf.DSLTest do
 
   test "saves ordered tags" do
     msg_props = Foo.__message_props__()
-    assert [1, 2, 3] ++ Enum.to_list(5..16) == msg_props.ordered_tags
+    assert [1, 2, 3] ++ Enum.to_list(5..17) == msg_props.ordered_tags
   end
 
   test "supports embedded fields" do
@@ -127,6 +127,18 @@ defmodule Protobuf.DSLTest do
     assert %FieldProps{fnum: 10, name: "i", repeated?: true, packed?: true} = field_props[10]
   end
 
+  test "deprecated? is false by default" do
+    msg_props = Foo.__message_props__()
+    field_props = msg_props.field_props
+    assert %FieldProps{fnum: 10, name: "i", deprecated?: false} = field_props[10]
+  end
+
+  test "deprecated? can be set to true" do
+    msg_props = Foo.__message_props__()
+    field_props = msg_props.field_props
+    assert %FieldProps{fnum: 17, name: "p", deprecated?: true} = field_props[17]
+  end
+
   test "supports enum" do
     msg_props = TestMsg.EnumFoo.__message_props__()
     assert msg_props.enum? == true
@@ -165,7 +177,8 @@ defmodule Protobuf.DSLTest do
              l: %{},
              m: :UNKNOWN,
              n: 0.0,
-             o: []
+             o: [],
+             p: ""
            } == Foo.__default_struct__()
   end
 

--- a/test/support/test_msg.ex
+++ b/test/support/test_msg.ex
@@ -33,7 +33,7 @@ defmodule TestMsg do
   defmodule Foo do
     use Protobuf, syntax: :proto3
 
-    defstruct [:a, :b, :c, :d, :e, :f, :g, :h, :i, :j, :k, :l, :m, :n, :o]
+    defstruct [:a, :b, :c, :d, :e, :f, :g, :h, :i, :j, :k, :l, :m, :n, :o, :p]
 
     field :a, 1, type: :int32
     field :b, 2, type: :fixed64
@@ -51,6 +51,7 @@ defmodule TestMsg do
     field :m, 14, type: EnumFoo, enum: true
     field :n, 15, type: :double
     field :o, 16, repeated: true, type: EnumFoo, enum: true
+    field :p, 17, type: :string, deprecated: true
   end
 
   defmodule Foo2 do


### PR DESCRIPTION
Spent some time digging for the `deprecated` field option, realized it existed but was just excluded from the field options struct. Adding it here because we already have that data, and it's useful to be able to know programmatically if a field is deprecated.

Also updated the README with instructions on how to get the test suite running.