### PR TITLE
Improve performance of __default_struct__/0

### DIFF
--- a/lib/protobuf/dsl.ex
+++ b/lib/protobuf/dsl.ex
@@ -27,6 +27,11 @@ defmodule Protobuf.DSL do
     enum_fields = enum_fields(msg_props, false)
     default_struct = Map.put(default_fields, :__struct__, env.module)
 
+    default_struct_proto3 =
+      Enum.reduce(enum_fields, default_struct, fn {name, type}, acc ->
+        Map.put(acc, name, type.key(0))
+      end)
+
     quote do
       def __message_props__ do
         unquote(Macro.escape(msg_props))
@@ -36,11 +41,7 @@ defmodule Protobuf.DSL do
 
       if unquote(syntax == :proto3) do
         def __default_struct__ do
-          struct = unquote(Macro.escape(default_struct))
-
-          Enum.reduce(unquote(Macro.escape(enum_fields)), struct, fn {name, type}, acc ->
-            Map.put(acc, name, type.key(0))
-          end)
+          unquote(Macro.escape(default_struct_proto3))
         end
       else
         def __default_struct__ do


### PR DESCRIPTION
In this code we're building the default struct for Proto2 at compile time, and then building off from that struct to make the proto3 struct **at runtime**. There's no need to do that at runtime as far as I can tell, we can just do that at compile time too. That makes `MyProtoSchema.new()` about 3.5x faster from my benchmarks.

cc @tony612 