### PR TITLE
Encode required enums for proto2

### DIFF
--- a/test/protobuf/encoder_test.exs
+++ b/test/protobuf/encoder_test.exs
@@ -171,4 +171,17 @@ defmodule Protobuf.EncoderTest do
                fields: %{"valid" => %Google.Protobuf.Value{kind: {:bool_value, true}}}
              )
   end
+
+  test "encodes default value for proto2" do
+    # Includes required
+    msg = TestMsg.Bar2.new(a: 0)
+    assert Encoder.encode(msg) == <<8, 0>>
+
+    # Excludes optionals at default value
+    msg = TestMsg.Bar2.new(a: 0, b: 0)
+    assert Encoder.encode(msg) == <<8, 0>>
+
+    msg = TestMsg.Bar2.new(a: 0, b: 1)
+    assert Encoder.encode(msg) == <<8, 0, 16, 1>>
+  end
 end

--- a/test/support/test_msg.ex
+++ b/test/support/test_msg.ex
@@ -123,4 +123,19 @@ defmodule TestMsg do
     field :child, 1, type: Link
     field :value, 2, type: :int32
   end
+
+  defmodule Bar2.Enum do
+    @moduledoc false
+    use Protobuf, enum: true, syntax: :proto2
+
+    field :a, 0
+    field :b, 1
+  end
+
+  defmodule Bar2 do
+    use Protobuf, syntax: :proto2
+
+    field :a, 1, required: true, type: Bar2.Enum, enum: true
+    field :b, 2, optional: true, type: Bar2.Enum, enum: true
+  end
 end


### PR DESCRIPTION
This MR fixes the encoder when it is encoding required enums in proto2 by not skipping them when they are the "default" value.

A specific example that I have ran into that was causing issues is encoding `CommandAck` from the Pulsar protobuf [spec](https://github.com/apache/pulsar/blob/master/pulsar-common/src/main/proto/PulsarApi.proto). 

```protobuf
message CommandAck {
    enum AckType {
        Individual = 0;
        Cumulative = 1;
    }

    required uint64 consumer_id       = 1;
    required AckType ack_type         = 2;
    ...
}
```

```elixir
%Proto.CommandAck{
  ack_type: 0,
  consumer_id: 1,
  ...
}
```

`ack_type` is a required enum. This library was skipping encoding due to it being the default value which causes the pulsar server to close the connection and log an exception saying the message was missing fields. 

Encoding the above struct with this library outputs the following binary.

```elixir
<<8, 1, 26, 27, 8, 123, 16, 200, 3, 24, 255, 255, 255, 255, 255, 255, 255, 255, 255, 1, 32, 255, 255, 255, 255, 255, 255, 255, 255, 255, 1, 48, 0, 56, 0>>
```
I tested encoding the same struct with `:exprotobuf` library and the output is a little different.

```elixir
<<8, 1, 16, 0, 26, 27, 8, 123, 16, 200, 3, 24, 255, 255, 255, 255, 255, 255, 255, 255, 255, 1, 32, 255, 255, 255, 255, 255, 255, 255, 255, 255, 1, 48, 0, 56, 0>>
```

With this fix, the output from this library is the same as `:exprotobuf`.