### PR TITLE
Generate enum types

### DIFF
--- a/lib/protobuf/protoc/generator/enum.ex
+++ b/lib/protobuf/protoc/generator/enum.ex
@@ -10,8 +10,18 @@ defmodule Protobuf.Protoc.Generator.Enum do
     fields = Enum.map(desc.value, fn f -> generate_field(f) end)
     msg_name = Util.mod_name(ctx, ns ++ [name])
     generate_desc = if ctx.gen_descriptors?, do: desc, else: nil
+    type = generate_type(desc.value)
 
-    Protobuf.Protoc.Template.enum(msg_name, msg_opts(ctx, desc), fields, generate_desc)
+    Protobuf.Protoc.Template.enum(msg_name, msg_opts(ctx, desc), fields, type, generate_desc)
+  end
+
+  def generate_type(fields) do
+    field_values =
+      fields
+      |> Enum.map(fn f -> ":#{f.name} | #{f.number}" end)
+      |> Enum.join(" | ")
+
+    "@type t :: " <> field_values
   end
 
   def generate_field(f) do

--- a/lib/protobuf/protoc/generator/enum.ex
+++ b/lib/protobuf/protoc/generator/enum.ex
@@ -18,10 +18,10 @@ defmodule Protobuf.Protoc.Generator.Enum do
   def generate_type(fields) do
     field_values =
       fields
-      |> Enum.map(fn f -> ":#{f.name} | #{f.number}" end)
+      |> Enum.map(fn f -> ":#{f.name}" end)
       |> Enum.join(" | ")
 
-    "@type t :: " <> field_values
+    "@type t :: integer | " <> field_values
   end
 
   def generate_field(f) do

--- a/lib/protobuf/protoc/generator/message.ex
+++ b/lib/protobuf/protoc/generator/message.ex
@@ -118,8 +118,8 @@ defmodule Protobuf.Protoc.Generator.Message do
     String.pad_trailing("#{name}:", len + 1)
   end
 
-  defp fmt_type(%{opts: %{enum: true}, label: "repeated"}), do: "[atom | integer]"
-  defp fmt_type(%{opts: %{enum: true}}), do: "atom | integer"
+  # defp fmt_type(%{opts: %{enum: true}, label: "repeated"} = l ), do: IO.inspect l; "[atom | integer]"
+  # defp fmt_type(%{opts: %{enum: true}}=l), do: IO.inspect l;  "atom | integer"
 
   defp fmt_type(%{opts: %{map: true}, map: {{k_type, k_name}, {v_type, v_name}}}) do
     k_type = type_to_spec(k_type, k_name)
@@ -137,11 +137,11 @@ defmodule Protobuf.Protoc.Generator.Message do
 
   defp type_to_spec(enum, type, repeated \\ false)
 
-  defp type_to_spec(:TYPE_MESSAGE, type, true),
-    do: TypeUtil.enum_to_spec(:TYPE_MESSAGE, type, true)
+  defp type_to_spec(:TYPE_MESSAGE, type, repeated),
+    do: TypeUtil.enum_to_spec(:TYPE_MESSAGE, type, repeated)
 
-  defp type_to_spec(:TYPE_MESSAGE, type, false),
-    do: TypeUtil.enum_to_spec(:TYPE_MESSAGE, type, false)
+  defp type_to_spec(:TYPE_ENUM, type, repeated),
+    do: TypeUtil.enum_to_spec(:TYPE_ENUM, type, repeated)
 
   defp type_to_spec(enum, _, _), do: TypeUtil.enum_to_spec(enum)
 

--- a/lib/protobuf/protoc/generator/message.ex
+++ b/lib/protobuf/protoc/generator/message.ex
@@ -118,9 +118,6 @@ defmodule Protobuf.Protoc.Generator.Message do
     String.pad_trailing("#{name}:", len + 1)
   end
 
-  # defp fmt_type(%{opts: %{enum: true}, label: "repeated"} = l ), do: IO.inspect l; "[atom | integer]"
-  # defp fmt_type(%{opts: %{enum: true}}=l), do: IO.inspect l;  "atom | integer"
-
   defp fmt_type(%{opts: %{map: true}, map: {{k_type, k_name}, {v_type, v_name}}}) do
     k_type = type_to_spec(k_type, k_name)
     v_type = type_to_spec(v_type, v_name)

--- a/lib/protobuf/protoc/template.ex
+++ b/lib/protobuf/protoc/template.ex
@@ -13,7 +13,7 @@ defmodule Protobuf.Protoc.Template do
     trim: true
   )
 
-  EEx.function_from_file(:def, :enum, @enum_tmpl, [:name, :options, :fields, :desc], trim: true)
+  EEx.function_from_file(:def, :enum, @enum_tmpl, [:name, :options, :fields, :type, :desc], trim: true)
 
   EEx.function_from_file(:def, :service, @svc_tmpl, [:mod_name, :name, :methods, :desc],
     trim: true

--- a/lib/protobuf/protoc/template.ex
+++ b/lib/protobuf/protoc/template.ex
@@ -13,7 +13,9 @@ defmodule Protobuf.Protoc.Template do
     trim: true
   )
 
-  EEx.function_from_file(:def, :enum, @enum_tmpl, [:name, :options, :fields, :type, :desc], trim: true)
+  EEx.function_from_file(:def, :enum, @enum_tmpl, [:name, :options, :fields, :type, :desc],
+    trim: true
+  )
 
   EEx.function_from_file(:def, :service, @svc_tmpl, [:mod_name, :name, :methods, :desc],
     trim: true

--- a/lib/protobuf/type_util.ex
+++ b/lib/protobuf/type_util.ex
@@ -37,4 +37,6 @@ defmodule Protobuf.TypeUtil do
   def enum_to_spec(_), do: "any"
   def enum_to_spec(:TYPE_MESSAGE, type, true = _repeated), do: "#{type}.t"
   def enum_to_spec(:TYPE_MESSAGE, type, false = _repeated), do: "#{type}.t | nil"
+  def enum_to_spec(:TYPE_ENUM, type, true = _repeated), do: "[#{type}.t]"
+  def enum_to_spec(:TYPE_ENUM, type, false = _repeated), do: "#{type}.t"
 end

--- a/priv/templates/enum.ex.eex
+++ b/priv/templates/enum.ex.eex
@@ -1,6 +1,8 @@
 defmodule <%= name %> do
   @moduledoc false
   use Protobuf<%= options %>
+  
+  <%= type %>
 
   <%= if not is_nil(desc) do %>
   def descriptor do

--- a/test/protobuf/protoc/generator/enum_test.exs
+++ b/test/protobuf/protoc/generator/enum_test.exs
@@ -19,7 +19,7 @@ defmodule Protobuf.Protoc.Generator.EnumTest do
     msg = Generator.generate(ctx, desc)
     assert msg =~ "defmodule EnumFoo do\n"
     assert msg =~ "use Protobuf, enum: true\n"
-    assert msg =~ "@type t :: :A | 0 | :B | 1\n"
+    assert msg =~ "@type t :: integer | :A | :B\n"
     refute msg =~ "defstruct "
     assert msg =~ "field :A, 0\n  field :B, 1\n"
   end

--- a/test/protobuf/protoc/generator/enum_test.exs
+++ b/test/protobuf/protoc/generator/enum_test.exs
@@ -19,6 +19,7 @@ defmodule Protobuf.Protoc.Generator.EnumTest do
     msg = Generator.generate(ctx, desc)
     assert msg =~ "defmodule EnumFoo do\n"
     assert msg =~ "use Protobuf, enum: true\n"
+    assert msg =~ "@type t :: :A | 0 | :B | 1\n"
     refute msg =~ "defstruct "
     assert msg =~ "field :A, 0\n  field :B, 1\n"
   end

--- a/test/protobuf/protoc/generator/message_test.exs
+++ b/test/protobuf/protoc/generator/message_test.exs
@@ -281,7 +281,7 @@ defmodule Protobuf.Protoc.Generator.MessageTest do
       )
 
     {[], [msg]} = Generator.generate(ctx, desc)
-    assert msg =~ "a: atom | integer"
+    assert msg =~ "a: FooBar.AbCd.EnumFoo.t"
     assert msg =~ "field :a, 1, optional: true, type: FooBar.AbCd.EnumFoo, enum: true\n"
   end
 


### PR DESCRIPTION
The protoc plugin generates structs for `message`s together with their types. It doesn't however do that for `enum`s and it could be very helpful to generate types for enums too, so that they can be reffered to in other areas of the code.

Let me know what you think :)