### PR TITLE
New feature: JSON decoding

### DIFF
--- a/lib/protobuf/dsl.ex
+++ b/lib/protobuf/dsl.ex
@@ -106,6 +106,12 @@ defmodule Protobuf.DSL do
     num_to_atom = for {fnum, %{name_atom: name_atom}} <- props, do: {fnum, name_atom}
     atom_to_num = for {name_atom, fnum, _opts} <- fields, do: {name_atom, fnum}, into: %{}
 
+    string_or_num_to_atom =
+      for {fnum, %{name: name, name_atom: name_atom}} <- props,
+          key <- [fnum, name],
+          do: {key, name_atom},
+          into: %{}
+
     Enum.map(atom_to_num, fn {name_atom, fnum} ->
       quote do
         def value(unquote(name_atom)), do: unquote(fnum)
@@ -124,6 +130,9 @@ defmodule Protobuf.DSL do
       [
         quote do
           def mapping(), do: unquote(Macro.escape(atom_to_num))
+        end,
+        quote do
+          def __reverse_mapping__(), do: unquote(Macro.escape(string_or_num_to_atom))
         end
       ]
   end

--- a/lib/protobuf/json.ex
+++ b/lib/protobuf/json.ex
@@ -157,8 +157,8 @@ defmodule Protobuf.JSON do
   @spec encode(struct, [encode_opt]) ::
           {:ok, String.t()} | {:error, EncodeError.t() | Exception.t()}
   def encode(struct, opts \\ []) do
-    if Code.ensure_loaded?(Jason) do
-      with {:ok, map} <- to_encodable(struct, opts), do: Jason.encode(map)
+    if jason = load_jason() do
+      with {:ok, map} <- to_encodable(struct, opts), do: jason.encode(map)
     else
       {:error, EncodeError.new(:no_json_lib)}
     end
@@ -244,8 +244,8 @@ defmodule Protobuf.JSON do
   """
   @spec decode(iodata, module) :: {:ok, struct} | {:error, DecodeError.t() | Exception.t()}
   def decode(iodata, module) do
-    if Code.ensure_loaded?(Jason) do
-      with {:ok, json_data} <- Jason.decode(iodata),
+    if jason = load_jason() do
+      with {:ok, json_data} <- jason.decode(iodata),
            do: from_decoded(json_data, module)
     else
       {:error, DecodeError.new(:no_json_lib)}
@@ -275,4 +275,6 @@ defmodule Protobuf.JSON do
   catch
     error -> {:error, DecodeError.new(error)}
   end
+
+  defp load_jason, do: Code.ensure_loaded?(Jason) and Jason
 end

--- a/lib/protobuf/json/decode.ex
+++ b/lib/protobuf/json/decode.ex
@@ -38,7 +38,7 @@ defmodule Protobuf.JSON.Decode do
 
   @float_types [:float, :double]
 
-  def from_json_data(data, module) when is_map(data) do
+  def from_json_data(data, module) when is_map(data) and is_atom(module) do
     message_props = Utils.message_props(module)
     regular = decode_regular_fields(data, message_props)
     oneofs = decode_oneof_fields(data, message_props)
@@ -48,7 +48,7 @@ defmodule Protobuf.JSON.Decode do
     |> struct(oneofs)
   end
 
-  def from_json_data(data, _module), do: throw({:bad_message, data})
+  def from_json_data(data, module) when is_atom(module), do: throw({:bad_message, data})
 
   defp decode_regular_fields(data, %{field_props: field_props}) do
     for {_field_num, %{oneof: nil} = prop} <- field_props,

--- a/lib/protobuf/json/decode.ex
+++ b/lib/protobuf/json/decode.ex
@@ -60,7 +60,7 @@ defmodule Protobuf.JSON.Decode do
   defp decode_oneof_fields(data, %{field_props: field_props, oneof: oneofs}) do
     for {oneof, index} <- oneofs,
         {_field_num, %{oneof: ^index} = prop} <- field_props,
-        value = field_value(prop, data),
+        not is_nil(value = field_value(prop, data)),
         reduce: %{} do
       %{^oneof => _duplicated} -> throw({:duplicated_oneof, oneof})
       acc -> Map.put(acc, oneof, {prop.name_atom, decode_value(prop, value)})

--- a/lib/protobuf/json/decode.ex
+++ b/lib/protobuf/json/decode.ex
@@ -1,0 +1,204 @@
+defmodule Protobuf.JSON.Decode do
+  @moduledoc false
+
+  import Bitwise, only: [bsl: 2]
+
+  alias Protobuf.JSON.Utils
+
+  @compile {:inline,
+            field_value: 2,
+            decode_map: 2,
+            decode_repeated: 2,
+            decode_integer: 1,
+            decode_float: 1,
+            parse_float: 1,
+            decode_bytes: 1,
+            decode_key: 3,
+            parse_key: 2}
+
+  @int32_range -bsl(1, 31)..(bsl(1, 31) - 1)
+  @int64_range -bsl(1, 63)..(bsl(1, 63) - 1)
+  @uint32_range 0..(bsl(1, 32) - 1)
+  @uint64_range 0..(bsl(1, 64) - 1)
+
+  @int_ranges %{
+    int32: @int32_range,
+    int64: @int64_range,
+    sint32: @int32_range,
+    sint64: @int64_range,
+    sfixed32: @int32_range,
+    sfixed64: @int64_range,
+    fixed32: @int32_range,
+    fixed64: @int64_range,
+    uint32: @uint32_range,
+    uint64: @uint64_range
+  }
+
+  @int_types Map.keys(@int_ranges)
+
+  @float_types [:float, :double]
+
+  def from_json_data(data, module) when is_map(data) do
+    message_props = Utils.message_props(module)
+    regular = decode_regular_fields(data, message_props)
+    oneofs = decode_oneof_fields(data, message_props)
+
+    module.__default_struct__()
+    |> struct(regular)
+    |> struct(oneofs)
+  end
+
+  def from_json_data(data, _module), do: throw({:bad_message, data})
+
+  defp decode_regular_fields(data, %{field_props: field_props}) do
+    for {_field_num, %{oneof: nil} = prop} <- field_props,
+        value = field_value(prop, data) do
+      {prop.name_atom, decode_value(prop, value)}
+    end
+  end
+
+  defp decode_oneof_fields(data, %{field_props: field_props, oneof: oneofs}) do
+    for {oneof, index} <- oneofs,
+        {_field_num, %{oneof: ^index} = prop} <- field_props,
+        value = field_value(prop, data),
+        reduce: %{} do
+      %{^oneof => _duplicated} -> throw({:duplicated_oneof, oneof})
+      acc -> Map.put(acc, oneof, {prop.name_atom, decode_value(prop, value)})
+    end
+  end
+
+  defp field_value(%{json_name: json_key, name: name_key}, data) do
+    case data do
+      %{^json_key => value} -> value
+      %{^name_key => value} -> value
+      _ -> nil
+    end
+  end
+
+  defp decode_value(%{map?: true} = prop, map), do: decode_map(prop, map)
+  defp decode_value(%{repeated?: true} = prop, list), do: decode_repeated(prop, list)
+  defp decode_value(%{repeated?: false} = prop, value), do: decode_singular(prop, value)
+
+  defp decode_map(%{type: module, name_atom: field}, map) when is_map(map) do
+    %{field_props: field_props, field_tags: field_tags} = Utils.message_props(module)
+    key_type = field_props[field_tags[:key]].type
+    val_prop = field_props[field_tags[:value]]
+
+    for {key, val} <- map, into: %{} do
+      {decode_key(key_type, key, field), decode_singular(val_prop, val)}
+    end
+  end
+
+  defp decode_map(prop, bad_map), do: throw({:bad_map, prop.name_atom, bad_map})
+
+  defp decode_key(type, key, field) when is_binary(key) do
+    case parse_key(type, key) do
+      {:ok, decoded} -> decoded
+      :error -> throw({:bad_map_key, field, type, key})
+    end
+  end
+
+  defp decode_key(type, key, field), do: throw({:bad_map_key, field, type, key})
+
+  # Map keys can be of any scalar type except float, double and bytes. they
+  # must always be wrapped in strings. Other types should not compile.
+  defp parse_key(:string, key), do: {:ok, key}
+  defp parse_key(:bool, "true"), do: {:ok, true}
+  defp parse_key(:bool, "false"), do: {:ok, false}
+  defp parse_key(type, key) when type in @int_types, do: parse_int(key)
+  defp parse_key(_type, _key), do: :error
+
+  defp decode_repeated(prop, value) when is_list(value) do
+    for val <- value, do: decode_singular(prop, val)
+  end
+
+  defp decode_repeated(prop, value) do
+    throw({:bad_repeated, prop.name_atom, value})
+  end
+
+  defp decode_singular(%{type: :string} = prop, value) do
+    if is_binary(value),
+      do: value,
+      else: throw({:bad_string, prop.name_atom, value})
+  end
+
+  defp decode_singular(%{type: :bool} = prop, value) do
+    if is_boolean(value),
+      do: value,
+      else: throw({:bad_bool, prop.name_atom, value})
+  end
+
+  defp decode_singular(%{type: type} = prop, value) when type in @int_types do
+    with {:ok, integer} <- decode_integer(value),
+         true <- integer in @int_ranges[type] do
+      integer
+    else
+      _ -> throw({:bad_int, prop.name_atom, value})
+    end
+  end
+
+  defp decode_singular(%{type: type} = prop, value) when type in @float_types do
+    case decode_float(value) do
+      {:ok, float} -> float
+      _ -> throw({:bad_float, prop.name_atom, value})
+    end
+  end
+
+  defp decode_singular(%{type: :bytes} = prop, value) do
+    with true <- is_binary(value),
+         {:ok, bytes} <- decode_bytes(value) do
+      bytes
+    else
+      _ -> throw({:bad_bytes, prop.name_atom})
+    end
+  end
+
+  defp decode_singular(%{type: {:enum, enum}} = prop, value) do
+    Map.get_lazy(enum.__reverse_mapping__(), value, fn ->
+      if is_integer(value) && value in @int32_range,
+        do: value,
+        else: throw({:bad_enum, prop.name_atom, value})
+    end)
+  end
+
+  defp decode_singular(%{type: module, embedded?: true}, value) do
+    from_json_data(value, module)
+  end
+
+  defp decode_integer(integer) when is_integer(integer), do: {:ok, integer}
+  defp decode_integer(string) when is_binary(string), do: parse_int(string)
+  defp decode_integer(_bad), do: :error
+
+  defp parse_int(string) do
+    case Integer.parse(string) do
+      {int, ""} -> {:ok, int}
+      _ -> :error
+    end
+  end
+
+  defp decode_float(float) when is_float(float), do: {:ok, float}
+  defp decode_float(string) when is_binary(string), do: parse_float(string)
+  defp decode_float(_bad), do: :error
+
+  defp parse_float("-Infinity"), do: {:ok, :negative_infinity}
+  defp parse_float("Infinity"), do: {:ok, :infinity}
+  defp parse_float("NaN"), do: {:ok, :nan}
+
+  defp parse_float(string) do
+    case Float.parse(string) do
+      {float, ""} -> {:ok, float}
+      _ -> :error
+    end
+  end
+
+  # Both url-encoded and regular base64 are accepted, with and without padding.
+  defp decode_bytes(bytes) do
+    pattern = :binary.compile_pattern(["-", "_"])
+
+    if String.contains?(bytes, pattern) do
+      Base.url_decode64(bytes, padding: false)
+    else
+      Base.decode64(bytes, padding: false)
+    end
+  end
+end

--- a/lib/protobuf/json/decode_error.ex
+++ b/lib/protobuf/json/decode_error.ex
@@ -1,0 +1,57 @@
+defmodule Protobuf.JSON.DecodeError do
+  defexception [:message]
+
+  @type t :: %__MODULE__{message: String.t()}
+
+  def new({:unsupported_syntax, syntax}) do
+    %__MODULE__{message: "JSON encoding of '#{syntax}' syntax is unsupported, try proto3"}
+  end
+
+  def new(:no_json_lib) do
+    %__MODULE__{message: "JSON library not loaded, make sure to add :jason to your mix.exs file"}
+  end
+
+  def new({:bad_message, data}) do
+    %__MODULE__{message: "JSON map expected, got: #{inspect(data)}"}
+  end
+
+  def new({:bad_string, field, value}) do
+    %__MODULE__{message: "Field '#{field}' has an invalid string (#{inspect(value)})"}
+  end
+
+  def new({:bad_bool, field, value}) do
+    %__MODULE__{message: "Field '#{field}' has an invalid boolean (#{inspect(value)})"}
+  end
+
+  def new({:bad_int, field, value}) do
+    %__MODULE__{message: "Field '#{field}' has an invalid integer (#{inspect(value)})"}
+  end
+
+  def new({:bad_float, field, value}) do
+    %__MODULE__{message: "Field '#{field}' has an invalid floating point (#{inspect(value)})"}
+  end
+
+  def new({:bad_bytes, field}) do
+    %__MODULE__{message: "Field '#{field}' has an invalid Base64-encoded byte sequence"}
+  end
+
+  def new({:bad_enum, field, value}) do
+    %__MODULE__{message: "Field '#{field}' has an invalid enum value (#{inspect(value)})"}
+  end
+
+  def new({:bad_map, field, value}) do
+    %__MODULE__{message: "Field '#{field}' has an invalid map (#{inspect(value)})"}
+  end
+
+  def new({:bad_map_key, field, type, value}) do
+    %__MODULE__{message: "Field '#{field}' has an invalid map key (#{type}: #{inspect(value)})"}
+  end
+
+  def new({:duplicated_oneof, oneof}) do
+    %__MODULE__{message: "Oneof field '#{oneof}' cannot be set twice"}
+  end
+
+  def new({:bad_repeated, field, value}) do
+    %__MODULE__{message: "Repeated field '#{field}' expected a list, got #{inspect(value)}"}
+  end
+end

--- a/test/protobuf/dsl_test.exs
+++ b/test/protobuf/dsl_test.exs
@@ -154,6 +154,17 @@ defmodule Protobuf.DSLTest do
     assert_raise FunctionClauseError, fn -> TestMsg.EnumFoo.key(5) end
     assert TestMsg.EnumFoo.mapping() == %{UNKNOWN: 0, A: 1, B: 2, C: 4, D: 4, E: 4}
 
+    assert TestMsg.EnumFoo.__reverse_mapping__() == %{
+             0 => :UNKNOWN,
+             1 => :A,
+             2 => :B,
+             4 => :C,
+             "A" => :A,
+             "B" => :B,
+             "C" => :C,
+             "UNKNOWN" => :UNKNOWN
+           }
+
     assert %FieldProps{fnum: 11, type: {:enum, TestMsg.EnumFoo}, wire_type: 0} =
              Foo.__message_props__().field_props[11]
   end

--- a/test/protobuf/json/decode_test.exs
+++ b/test/protobuf/json/decode_test.exs
@@ -475,6 +475,16 @@ defmodule Protobuf.JSON.DecodeTest do
       data = %{"a" => 0, "d" => ""}
       decoded = OneofProto3.new(first: {:a, 0}, second: {:d, ""})
       assert decode(data, OneofProto3) == {:ok, decoded}
+
+      defmodule BooleanOneof do
+        use Protobuf, syntax: :proto3
+        oneof :zero, 0
+        field :bool, 1, type: :bool, oneof: 0
+      end
+
+      data = %{"bool" => false}
+      decoded = BooleanOneof.new(zero: {:bool, false})
+      assert decode(data, BooleanOneof) == {:ok, decoded}
     end
 
     test "multiple non-null fields set in a single oneof is invalid" do

--- a/test/protobuf/json/decode_test.exs
+++ b/test/protobuf/json/decode_test.exs
@@ -1,0 +1,585 @@
+defmodule Protobuf.JSON.DecodeTest do
+  use ExUnit.Case, async: true
+
+  alias TestMsg.{Foo, Foo.Bar, Maps, OneofProto3, Parent, Parent.Child, Scalars}
+
+  def decode(data, module) do
+    Protobuf.JSON.from_decoded(data, module)
+  end
+
+  def error(msg) do
+    {:error, %Protobuf.JSON.DecodeError{message: msg}}
+  end
+
+  describe "strings" do
+    test "utf-8 is valid" do
+      data = %{"string" => "エリクサー"}
+      decoded = Scalars.new!(string: "エリクサー")
+      assert decode(data, Scalars) == {:ok, decoded}
+    end
+
+    test "integer is invalid" do
+      data = %{"string" => 123}
+      msg = "Field 'string' has an invalid string (123)"
+      assert decode(data, Scalars) == error(msg)
+    end
+
+    test "15-bit bitstring is invalid" do
+      data = %{"string" => <<1::15>>}
+      msg = "Field 'string' has an invalid string (<<0, 1::size(7)>>)"
+      assert decode(data, Scalars) == error(msg)
+    end
+  end
+
+  describe "booleans" do
+    test "actual boolean is valid" do
+      data = %{"bool" => true}
+      decoded = Scalars.new!(bool: true)
+      assert decode(data, Scalars) == {:ok, decoded}
+    end
+
+    test "string is invalid" do
+      data = %{"bool" => "true"}
+      msg = "Field 'bool' has an invalid boolean (\"true\")"
+      assert decode(data, Scalars) == error(msg)
+    end
+
+    test "number is invalid" do
+      data = %{"bool" => 1}
+      msg = "Field 'bool' has an invalid boolean (1)"
+      assert decode(data, Scalars) == error(msg)
+    end
+  end
+
+  describe "integers" do
+    test "integer value is valid" do
+      data = %{"int32" => 999}
+      decoded = Scalars.new!(int32: 999)
+      assert decode(data, Scalars) == {:ok, decoded}
+
+      data = %{"sint32" => 999}
+      decoded = Scalars.new!(sint32: 999)
+      assert decode(data, Scalars) == {:ok, decoded}
+
+      data = %{"fixed64" => 999}
+      decoded = Scalars.new!(fixed64: 999)
+      assert decode(data, Scalars) == {:ok, decoded}
+
+      data = %{"sfixed64" => 999}
+      decoded = Scalars.new!(sfixed64: 999)
+      assert decode(data, Scalars) == {:ok, decoded}
+
+      data = %{"int32" => -999}
+      decoded = Scalars.new!(int32: -999)
+      assert decode(data, Scalars) == {:ok, decoded}
+
+      data = %{"sint32" => -999}
+      decoded = Scalars.new!(sint32: -999)
+      assert decode(data, Scalars) == {:ok, decoded}
+
+      data = %{"fixed64" => -999}
+      decoded = Scalars.new!(fixed64: -999)
+      assert decode(data, Scalars) == {:ok, decoded}
+
+      data = %{"sfixed64" => -999}
+      decoded = Scalars.new!(sfixed64: -999)
+      assert decode(data, Scalars) == {:ok, decoded}
+    end
+
+    test "string value is valid" do
+      data = %{"fixed32" => "999"}
+      decoded = Scalars.new!(fixed32: 999)
+      assert decode(data, Scalars) == {:ok, decoded}
+
+      data = %{"sfixed32" => "-999"}
+      decoded = Scalars.new!(sfixed32: -999)
+      assert decode(data, Scalars) == {:ok, decoded}
+
+      data = %{"int64" => "\u0031\u0032"}
+      decoded = Scalars.new!(int64: 12)
+      assert decode(data, Scalars) == {:ok, decoded}
+
+      data = %{"sint64" => "\u0031\u0032"}
+      decoded = Scalars.new!(sint64: 12)
+      assert decode(data, Scalars) == {:ok, decoded}
+    end
+
+    test "string value with extra characters is invalid" do
+      data = %{"uint32" => "999 "}
+      msg = "Field 'uint32' has an invalid integer (\"999 \")"
+      assert decode(data, Scalars) == error(msg)
+
+      data = %{"uint64" => "999aaa"}
+      msg = "Field 'uint64' has an invalid integer (\"999aaa\")"
+      assert decode(data, Scalars) == error(msg)
+    end
+
+    test "float value is invalid" do
+      data = %{"int32" => 9.99}
+      msg = "Field 'int32' has an invalid integer (9.99)"
+      assert decode(data, Scalars) == error(msg)
+    end
+
+    test "values outside upper and lower limits are invalid" do
+      msg = "Field 'int32' has an invalid integer (2147483648)"
+      assert decode(%{"int32" => 2_147_483_648}, Scalars) == error(msg)
+
+      msg = "Field 'sint32' has an invalid integer (2147483648)"
+      assert decode(%{"sint32" => 2_147_483_648}, Scalars) == error(msg)
+
+      msg = "Field 'fixed32' has an invalid integer (2147483648)"
+      assert decode(%{"fixed32" => 2_147_483_648}, Scalars) == error(msg)
+
+      msg = "Field 'sfixed32' has an invalid integer (2147483648)"
+      assert decode(%{"sfixed32" => 2_147_483_648}, Scalars) == error(msg)
+
+      msg = "Field 'uint32' has an invalid integer (4294967296)"
+      assert decode(%{"uint32" => 4_294_967_296}, Scalars) == error(msg)
+
+      msg = "Field 'int32' has an invalid integer (-2147483649)"
+      assert decode(%{"int32" => -2_147_483_649}, Scalars) == error(msg)
+
+      msg = "Field 'sint32' has an invalid integer (-2147483649)"
+      assert decode(%{"sint32" => -2_147_483_649}, Scalars) == error(msg)
+
+      msg = "Field 'fixed32' has an invalid integer (-2147483649)"
+      assert decode(%{"fixed32" => -2_147_483_649}, Scalars) == error(msg)
+
+      msg = "Field 'sfixed32' has an invalid integer (-2147483649)"
+      assert decode(%{"sfixed32" => -2_147_483_649}, Scalars) == error(msg)
+
+      msg = "Field 'uint32' has an invalid integer (-1)"
+      assert decode(%{"uint32" => -1}, Scalars) == error(msg)
+
+      msg = "Field 'int64' has an invalid integer (9223372036854775808)"
+      assert decode(%{"int64" => 9_223_372_036_854_775_808}, Scalars) == error(msg)
+
+      msg = "Field 'sint64' has an invalid integer (9223372036854775808)"
+      assert decode(%{"sint64" => 9_223_372_036_854_775_808}, Scalars) == error(msg)
+
+      msg = "Field 'fixed64' has an invalid integer (9223372036854775808)"
+      assert decode(%{"fixed64" => 9_223_372_036_854_775_808}, Scalars) == error(msg)
+
+      msg = "Field 'sfixed64' has an invalid integer (9223372036854775808)"
+      assert decode(%{"sfixed64" => 9_223_372_036_854_775_808}, Scalars) == error(msg)
+
+      msg = "Field 'uint64' has an invalid integer (18446744073709551616)"
+      assert decode(%{"uint64" => 18_446_744_073_709_551_616}, Scalars) == error(msg)
+
+      msg = "Field 'int64' has an invalid integer (-9223372036854775809)"
+      assert decode(%{"int64" => -9_223_372_036_854_775_809}, Scalars) == error(msg)
+
+      msg = "Field 'sint64' has an invalid integer (-9223372036854775809)"
+      assert decode(%{"sint64" => -9_223_372_036_854_775_809}, Scalars) == error(msg)
+
+      msg = "Field 'fixed64' has an invalid integer (-9223372036854775809)"
+      assert decode(%{"fixed64" => -9_223_372_036_854_775_809}, Scalars) == error(msg)
+
+      msg = "Field 'sfixed64' has an invalid integer (-9223372036854775809)"
+      assert decode(%{"sfixed64" => -9_223_372_036_854_775_809}, Scalars) == error(msg)
+
+      msg = "Field 'uint64' has an invalid integer (-1)"
+      assert decode(%{"uint64" => -1}, Scalars) == error(msg)
+    end
+
+    # TODO: Jason decodes integers in E notation as floats, e.g. 1e2 becomes
+    # 100.0 rather than 100. We need to figure out how to make them integers.
+    # We could try to guess with Float.ratio matching to {_, 1} or maybe with
+    # to_string matching ~r|\.0$| but this might be a bad idea in the end.
+    @tag :skip
+    test "values in E notation are valid"
+  end
+
+  describe "floating point" do
+    test "float value is valid" do
+      data = %{"float" => 1.234, "double" => 5.6789}
+      decoded = Scalars.new!(float: 1.234, double: 5.6789)
+      assert decode(data, Scalars) == {:ok, decoded}
+
+      data = %{"float" => -1.234, "double" => -5.6789}
+      decoded = Scalars.new!(float: -1.234, double: -5.6789)
+      assert decode(data, Scalars) == {:ok, decoded}
+
+      data = %{"float" => 1.23e3, "double" => 1.23e-2}
+      decoded = Scalars.new!(float: 1230.0, double: 0.0123)
+      assert decode(data, Scalars) == {:ok, decoded}
+    end
+
+    test "constants are valid" do
+      data = %{"float" => "NaN", "double" => "NaN"}
+      decoded = Scalars.new!(float: :nan, double: :nan)
+      assert decode(data, Scalars) == {:ok, decoded}
+
+      data = %{"float" => "Infinity", "double" => "Infinity"}
+      decoded = Scalars.new!(float: :infinity, double: :infinity)
+      assert decode(data, Scalars) == {:ok, decoded}
+
+      data = %{"float" => "-Infinity", "double" => "-Infinity"}
+      decoded = Scalars.new!(float: :negative_infinity, double: :negative_infinity)
+      assert decode(data, Scalars) == {:ok, decoded}
+    end
+
+    test "string value is valid" do
+      data = %{"float" => "1.234", "double" => "5.6789"}
+      decoded = Scalars.new!(float: 1.234, double: 5.6789)
+      assert decode(data, Scalars) == {:ok, decoded}
+
+      data = %{"float" => "-1.234", "double" => "-5.6789"}
+      decoded = Scalars.new!(float: -1.234, double: -5.6789)
+      assert decode(data, Scalars) == {:ok, decoded}
+
+      data = %{"float" => "1.23e3", "double" => "1.23e-2"}
+      decoded = Scalars.new!(float: 1230.0, double: 0.0123)
+      assert decode(data, Scalars) == {:ok, decoded}
+    end
+
+    test "string value with extra characters is invalid" do
+      data = %{"float" => "1.234 "}
+      msg = "Field 'float' has an invalid floating point (\"1.234 \")"
+      assert decode(data, Scalars) == error(msg)
+
+      data = %{"double" => "5.6789a"}
+      msg = "Field 'double' has an invalid floating point (\"5.6789a\")"
+      assert decode(data, Scalars) == error(msg)
+    end
+
+    test "other types are invalid" do
+      data = %{"float" => 5}
+      msg = "Field 'float' has an invalid floating point (5)"
+      assert decode(data, Scalars) == error(msg)
+
+      data = %{"double" => true}
+      msg = "Field 'double' has an invalid floating point (true)"
+      assert decode(data, Scalars) == error(msg)
+    end
+
+    # TODO: `double` values out of bounds will already get caught by Jason, `float`
+    # values however will need to be range-limited.
+    @tag :skip
+    test "values outside upper and lower limits are invalid"
+  end
+
+  describe "bytes" do
+    test "Base64 encoded string with padding is valid" do
+      data = %{"bytes" => "dGhpcyB3b3Jrcw=="}
+      decoded = Scalars.new!(bytes: "this works")
+      assert decode(data, Scalars) == {:ok, decoded}
+    end
+
+    test "Base64 encoded string without padding is valid" do
+      data = %{"bytes" => "dGhpcyB3b3Jrcw"}
+      decoded = Scalars.new!(bytes: "this works")
+      assert decode(data, Scalars) == {:ok, decoded}
+    end
+
+    test "Base64 URL-encoded string with padding is valid" do
+      data = %{"bytes" => "cGx1cyBzaWduICsgc2xhc2ggLw=="}
+      decoded = Scalars.new!(bytes: "plus sign + slash /")
+      assert decode(data, Scalars) == {:ok, decoded}
+    end
+
+    test "Base64 URL-encoded string without padding is valid" do
+      data = %{"bytes" => "cGx1cyBzaWduICsgc2xhc2ggLw"}
+      decoded = Scalars.new!(bytes: "plus sign + slash /")
+      assert decode(data, Scalars) == {:ok, decoded}
+    end
+
+    test "corrupt Base64 encoded string is invalid" do
+      data = %{"bytes" => "dGhpcyB3b3Jrc"}
+      msg = "Field 'bytes' has an invalid Base64-encoded byte sequence"
+      assert decode(data, Scalars) == error(msg)
+    end
+
+    test "other types are invalid" do
+      data = %{"bytes" => 5}
+      msg = "Field 'bytes' has an invalid Base64-encoded byte sequence"
+      assert decode(data, Scalars) == error(msg)
+
+      data = %{"bytes" => <<3::7>>}
+      msg = "Field 'bytes' has an invalid Base64-encoded byte sequence"
+      assert decode(data, Scalars) == error(msg)
+    end
+  end
+
+  describe "enums" do
+    test "known integer value is valid" do
+      data = %{"j" => 4}
+      decoded = Foo.new!(j: :C)
+      assert decode(data, Foo) == {:ok, decoded}
+    end
+
+    test "known string value is valid" do
+      data = %{"j" => "C"}
+      decoded = Foo.new!(j: :C)
+      assert decode(data, Foo) == {:ok, decoded}
+    end
+
+    test "unknown integer value is valid" do
+      data = %{"j" => 999}
+      decoded = Foo.new!(j: 999)
+      assert decode(data, Foo) == {:ok, decoded}
+    end
+
+    test "integer value out of the 32-bit range is invalid" do
+      data = %{"j" => 2_147_483_648}
+      msg = "Field 'j' has an invalid enum value (2147483648)"
+      assert decode(data, Foo) == error(msg)
+
+      data = %{"j" => -2_147_483_649}
+      msg = "Field 'j' has an invalid enum value (-2147483649)"
+      assert decode(data, Foo) == error(msg)
+    end
+
+    test "unknown string value is invalid" do
+      data = %{"j" => "INVALID"}
+      msg = "Field 'j' has an invalid enum value (\"INVALID\")"
+      assert decode(data, Foo) == error(msg)
+
+      data = %{"j" => "1"}
+      msg = "Field 'j' has an invalid enum value (\"1\")"
+      assert decode(data, Foo) == error(msg)
+    end
+
+    test "types other than string and integer are invalid" do
+      data = %{"j" => true}
+      msg = "Field 'j' has an invalid enum value (true)"
+      assert decode(data, Foo) == error(msg)
+
+      data = %{"j" => 4.2}
+      msg = "Field 'j' has an invalid enum value (4.2)"
+      assert decode(data, Foo) == error(msg)
+    end
+  end
+
+  describe "maps" do
+    test "matching key and value types are valid" do
+      data = %{
+        "mapii" => %{"-1" => -1, "0" => 0, "1" => 1, "999999999" => 999_999_999},
+        "mapbi" => %{"true" => 1, "false" => 0},
+        "mapsi" => %{"" => 0, "三" => 3, "meaning" => 42}
+      }
+
+      mapii = %{-1 => -1, 0 => 0, 1 => 1, 999_999_999 => 999_999_999}
+      mapbi = %{true => 1, false => 0}
+      mapsi = %{"" => 0, "三" => 3, "meaning" => 42}
+      decoded = Maps.new!(mapii: mapii, mapbi: mapbi, mapsi: mapsi)
+
+      assert decode(data, Maps) == {:ok, decoded}
+    end
+
+    test "incompatible key type is invalid" do
+      data = %{"mapii" => %{"not a number" => 1}}
+      msg = "Field 'mapii' has an invalid map key (int32: \"not a number\")"
+      assert decode(data, Maps) == error(msg)
+
+      data = %{"mapbi" => %{"not a bool" => 1}}
+      msg = "Field 'mapbi' has an invalid map key (bool: \"not a bool\")"
+      assert decode(data, Maps) == error(msg)
+    end
+
+    test "non-string key is invalid" do
+      data = %{"mapii" => %{1 => 1}}
+      msg = "Field 'mapii' has an invalid map key (int32: 1)"
+      assert decode(data, Maps) == error(msg)
+
+      data = %{"mapbi" => %{true => 1}}
+      msg = "Field 'mapbi' has an invalid map key (bool: true)"
+      assert decode(data, Maps) == error(msg)
+
+      data = %{"mapsi" => %{'chars' => 1}}
+      msg = "Field 'mapsi' has an invalid map key (string: 'chars')"
+      assert decode(data, Maps) == error(msg)
+    end
+
+    test "non-map is invalid" do
+      data = %{"mapii" => "not a map"}
+      msg = "Field 'mapii' has an invalid map (\"not a map\")"
+      assert decode(data, Maps) == error(msg)
+    end
+
+    test "null value is invalid" do
+      data = %{"mapsi" => %{"null integer" => nil}}
+      msg = "Field 'value' has an invalid integer (nil)"
+      assert decode(data, Maps) == error(msg)
+    end
+
+    test "mismatching value types are invalid" do
+      data = %{"mapsi" => %{"valid" => 1, "invalid" => %{}}}
+      msg = "Field 'value' has an invalid integer (%{})"
+      assert decode(data, Maps) == error(msg)
+
+      data = %{"mapsi" => %{"valid" => 1, "invalid" => []}}
+      msg = "Field 'value' has an invalid integer ([])"
+      assert decode(data, Maps) == error(msg)
+    end
+
+    # TODO: Jason ignores duplicates https://github.com/michalmuskala/jason/issues/33
+    @tag :skip
+    test "duplicated keys are invalid"
+  end
+
+  describe "embedded" do
+    test "decodes embedded messages" do
+      data = %{"e" => %{"a" => 12, "b" => "abc"}, "f" => 2}
+      decoded = Foo.new!(e: Bar.new!(a: 12, b: "abc"), f: 2)
+      assert decode(data, Foo) == {:ok, decoded}
+    end
+
+    test "empty map is valid" do
+      assert decode(%{}, Parent) == {:ok, Parent.new()}
+
+      data = %{"child" => %{"parent" => %{}}}
+      decoded = Parent.new!(child: Child.new!(parent: Parent.new()))
+      assert decode(data, Parent) == {:ok, decoded}
+    end
+
+    test "null value is ignored" do
+      data = %{"child" => nil}
+      decoded = Parent.new()
+      assert decode(data, Parent) == {:ok, decoded}
+    end
+
+    test "other types are invalid" do
+      data = %{"child" => "invalid"}
+      msg = "JSON map expected, got: \"invalid\""
+      assert decode(data, Parent) == error(msg)
+
+      data = %{"child" => 2}
+      msg = "JSON map expected, got: 2"
+      assert decode(data, Parent) == error(msg)
+
+      data = %{"child" => true}
+      msg = "JSON map expected, got: true"
+      assert decode(data, Parent) == error(msg)
+
+      data = %{"child" => []}
+      msg = "JSON map expected, got: []"
+      assert decode(data, Parent) == error(msg)
+    end
+  end
+
+  describe "oneofs" do
+    test "decodes oneof fields" do
+      data = %{"a" => 1, "d" => "d", "other" => "other"}
+      decoded = OneofProto3.new!(first: {:a, 1}, second: {:d, "d"}, other: "other")
+      assert decode(data, OneofProto3) == {:ok, decoded}
+    end
+
+    test "unset" do
+      data = %{}
+      decoded = OneofProto3.new()
+      assert decode(data, OneofProto3) == {:ok, decoded}
+    end
+
+    test "set to default value" do
+      data = %{"a" => 0, "d" => ""}
+      decoded = OneofProto3.new(first: {:a, 0}, second: {:d, ""})
+      assert decode(data, OneofProto3) == {:ok, decoded}
+    end
+
+    test "multiple non-null fields set in a single oneof is invalid" do
+      data = %{"a" => 0, "b" => ""}
+      msg = "Oneof field 'first' cannot be set twice"
+      assert decode(data, OneofProto3) == error(msg)
+    end
+
+    test "multiple fields set in a single oneof, one being non-null, is valid" do
+      data = %{"a" => 42, "b" => nil}
+      decoded = OneofProto3.new(first: {:a, 42})
+      assert decode(data, OneofProto3) == {:ok, decoded}
+
+      data = %{"a" => nil, "b" => "valid"}
+      decoded = OneofProto3.new(first: {:b, "valid"})
+      assert decode(data, OneofProto3) == {:ok, decoded}
+    end
+  end
+
+  describe "repeated" do
+    test "decodes repeated" do
+      data = %{
+        "g" => [1, "2"],
+        "h" => [%{"a" => 1}, %{"b" => "b"}],
+        "o" => ["UNKNOWN", 1, "B", 999]
+      }
+
+      decoded =
+        Foo.new!(g: [1, 2], h: [Bar.new(a: 1), Bar.new(b: "b")], o: [:UNKNOWN, :A, :B, 999])
+
+      assert decode(data, Foo) == {:ok, decoded}
+    end
+
+    test "detects invalid values inside list" do
+      data = %{"o" => [0, 1, "BAD_ENUM"]}
+      msg = "Field 'o' has an invalid enum value (\"BAD_ENUM\")"
+      assert decode(data, Foo) == error(msg)
+
+      data = %{"g" => [0, 1, "A"]}
+      msg = "Field 'g' has an invalid integer (\"A\")"
+      assert decode(data, Foo) == error(msg)
+
+      data = %{"h" => [%{}, "not an embed"]}
+      msg = "JSON map expected, got: \"not an embed\""
+      assert decode(data, Foo) == error(msg)
+    end
+
+    test "non-list values are invalid" do
+      data = %{"g" => "not a list"}
+      msg = "Repeated field 'g' expected a list, got \"not a list\""
+      assert decode(data, Foo) == error(msg)
+    end
+  end
+
+  test "unknown fields are ignored" do
+    data = %{"a" => 1, "unknown" => 2, false => true, "e" => %{"a" => 2, 3 => 4}}
+    decoded = Foo.new!(a: 1, e: Bar.new!(a: 2))
+    assert decode(data, Foo) == {:ok, decoded}
+  end
+
+  test "null values are treated as default" do
+    data = %{
+      "a" => nil,
+      "b" => nil,
+      "c" => nil,
+      "d" => nil,
+      "e" => %{"a" => nil, "b" => nil},
+      "f" => nil,
+      "g" => nil,
+      "h" => nil,
+      "i" => nil,
+      "j" => nil,
+      "k" => nil,
+      "l" => nil,
+      "m" => nil,
+      "n" => nil,
+      "non_matched" => nil,
+      "o" => nil,
+      "p" => nil
+    }
+
+    assert decode(data, Foo) == {:ok, Foo.new(e: Bar.new())}
+  end
+
+  test "recognizes default values" do
+    data = %{
+      "a" => 0,
+      "b" => "0",
+      "c" => "",
+      "d" => 0.0,
+      "e" => %{"a" => 0, "b" => ""},
+      "f" => 0,
+      "g" => [],
+      "h" => [],
+      "i" => [],
+      "j" => "UNKNOWN",
+      "k" => false,
+      "l" => %{},
+      "m" => "UNKNOWN",
+      "n" => 0.0,
+      "non_matched" => "",
+      "o" => [],
+      "p" => ""
+    }
+
+    assert decode(data, Foo) == {:ok, Foo.new(e: Bar.new())}
+  end
+end

--- a/test/protobuf/json_test.exs
+++ b/test/protobuf/json_test.exs
@@ -10,8 +10,13 @@ defmodule Protobuf.JSONTest do
     end
   end
 
-  test "string field with invalid UTF-8 data" do
+  test "encoding string field with invalid UTF-8 data" do
     message = Scalars.new!(string: "   \xff   ")
     assert {:error, %Jason.EncodeError{}} = Protobuf.JSON.encode(message)
+  end
+
+  test "decoding string field with invalid UTF-8 data" do
+    json = ~S|{"string":"   \xff   "}|
+    assert {:error, %Jason.DecodeError{}} = Protobuf.JSON.decode(json, Scalars)
   end
 end

--- a/test/support/doctest.ex
+++ b/test/support/doctest.ex
@@ -12,6 +12,8 @@ defmodule Car do
   @moduledoc false
   use Protobuf, syntax: :proto3
 
+  defstruct [:color, :top_speed]
+
   field :color, 1, type: Color, enum: true
   field :top_speed, 2, type: :float, json_name: "topSpeed"
 end

--- a/test/support/test_msg.ex
+++ b/test/support/test_msg.ex
@@ -65,31 +65,6 @@ defmodule TestMsg do
     field :non_matched, 101, type: :string
   end
 
-  defmodule Scalars do
-    @moduledoc false
-    use Protobuf, syntax: :proto3
-
-    field :string, 1, type: :string
-    field :bool, 2, type: :bool
-
-    field :float, 3, type: :float
-    field :double, 4, type: :double
-
-    field :int32, 5, type: :int32
-    field :uint32, 6, type: :uint32
-    field :sint32, 7, type: :sint32
-    field :fixed32, 8, type: :fixed32
-    field :sfixed32, 9, type: :sfixed32
-
-    field :int64, 10, type: :int64
-    field :uint64, 11, type: :uint64
-    field :sint64, 12, type: :sint64
-    field :fixed64, 13, type: :fixed64
-    field :sfixed64, 14, type: :sfixed64
-
-    field :bytes, 15, type: :bytes
-  end
-
   defmodule Foo2 do
     @moduledoc false
     use Protobuf, syntax: :proto2
@@ -180,6 +155,77 @@ defmodule TestMsg do
 
     field :a, 1, required: true, type: Bar2.Enum, enum: true
     field :b, 2, optional: true, type: Bar2.Enum, enum: true
+  end
+
+  defmodule Scalars do
+    @moduledoc false
+    use Protobuf, syntax: :proto3
+
+    defstruct [
+      :string,
+      :bool,
+      :float,
+      :double,
+      :int32,
+      :uint32,
+      :sint32,
+      :fixed32,
+      :sfixed32,
+      :int64,
+      :uint64,
+      :sint64,
+      :fixed64,
+      :sfixed64,
+      :bytes
+    ]
+
+    field :string, 1, type: :string
+    field :bool, 2, type: :bool
+
+    field :float, 3, type: :float
+    field :double, 4, type: :double
+
+    field :int32, 5, type: :int32
+    field :uint32, 6, type: :uint32
+    field :sint32, 7, type: :sint32
+    field :fixed32, 8, type: :fixed32
+    field :sfixed32, 9, type: :sfixed32
+
+    field :int64, 10, type: :int64
+    field :uint64, 11, type: :uint64
+    field :sint64, 12, type: :sint64
+    field :fixed64, 13, type: :fixed64
+    field :sfixed64, 14, type: :sfixed64
+
+    field :bytes, 15, type: :bytes
+  end
+
+  defmodule MapIntToInt do
+    use Protobuf, map: true, syntax: :proto3
+
+    defstruct [:key, :value]
+
+    field :key, 1, type: :int32
+    field :value, 2, type: :int32
+  end
+
+  defmodule MapBoolToInt do
+    use Protobuf, map: true, syntax: :proto3
+
+    defstruct [:key, :value]
+
+    field :key, 1, type: :bool
+    field :value, 2, type: :int32
+  end
+
+  defmodule Maps do
+    use Protobuf, syntax: :proto3
+
+    defstruct [:mapii, :mapbi, :mapsi]
+
+    field :mapii, 1, repeated: true, map: true, type: MapIntToInt
+    field :mapbi, 2, repeated: true, map: true, type: MapBoolToInt
+    field :mapsi, 3, repeated: true, map: true, type: MapFoo
   end
 
   defmodule Ext.EnumFoo do


### PR DESCRIPTION
Addresses the second part of #86. Follow-up to #105.

This feature allows us to decode messages from JSON in addition to protobuf binaries.

It follows Google's specs and reference implementation. Only `proto3` syntax is supported at the moment and some features, such as well-known types, are not fully supported yet.

JSON decoding relies on the `Jason` library. Support to other JSON engines may be added in the future.

https://developers.google.com/protocol-buffers/docs/proto3#json
https://developers.google.com/protocol-buffers/docs/reference/google.protobuf

Huge thanks again to @whatyouhide and @amiel for their support and effort put into this.

### Design notes

This implementation iterates over the fields metadata to read from the JSON input. This means unknown fields will always be ignored and also means that it optimizes for "dense" JSON data. When the input is "sparse", containing very few fields set, the performance might be suboptimal.

### TODO

- [x] Find more edge cases to cover and test
- [x] Document functions and their options
- [x] Compare behavior against reference implementations (Go, Python, Java, C++)

### Out of scope

- Define `from_json` and `to_json` helpers for each generated module.
- `proto2` support
- `Any` mapping
- Google's well-known types mapping
- Handle duplicated map keys

### Known issues

According to the specs, libraries should raise an error on duplicated map keys. This is not possible at the moment, due to this limitation in Jason: https://github.com/michalmuskala/jason/issues/33

Field names might also collide and fail silently: https://github.com/protocolbuffers/protobuf/issues/5063. So extra care is advised when defining custom json field names.