### PR TITLE
Leverage iodata on encoding

### DIFF
--- a/lib/protobuf/encoder.ex
+++ b/lib/protobuf/encoder.ex
@@ -100,7 +100,7 @@ defmodule Protobuf.Encoder do
   @spec encode_field(atom, any, FieldProps.t()) :: iodata
   defp encode_field(:normal, val, %{encoded_fnum: fnum, type: type, repeated?: is_repeated}) do
     repeated_or_not(val, is_repeated, fn v ->
-      [fnum, encode_type(type, v)]
+      [fnum | encode_type(type, v)]
     end)
   end
 
@@ -114,16 +114,16 @@ defmodule Protobuf.Encoder do
     repeated_or_not(val, repeated, fn v ->
       v = if is_map, do: struct(prop.type, %{key: elem(v, 0), value: elem(v, 1)}), else: v
       # so that oneof {:atom, v} can be encoded
-      encoded = encode(type, v, [])
-      byte_size = byte_size(encoded)
-      [fnum, encode_varint(byte_size), encoded]
+      encoded = encode(type, v, iolist: true)
+      byte_size = IO.iodata_length(encoded)
+      [fnum | encode_varint(byte_size)] ++ encoded
     end)
   end
 
   defp encode_field(:packed, val, %{type: type, encoded_fnum: fnum}) do
     encoded = Enum.map(val, fn v -> encode_type(type, v) end)
     byte_size = IO.iodata_length(encoded)
-    [fnum, encode_varint(byte_size), encoded]
+    [fnum | encode_varint(byte_size)] ++ encoded
   end
 
   @spec class_field(map) :: atom
@@ -140,12 +140,13 @@ defmodule Protobuf.Encoder do
   end
 
   @doc false
-  @spec encode_fnum(integer, integer) :: iodata
+  @spec encode_fnum(integer, integer) :: binary
   def encode_fnum(fnum, wire_type) do
     fnum
     |> bsl(3)
     |> bor(wire_type)
-    |> encode_varint
+    |> encode_varint()
+    |> IO.iodata_to_binary()
   end
 
   @doc false
@@ -162,19 +163,18 @@ defmodule Protobuf.Encoder do
   def encode_type(:bool, false), do: encode_varint(0)
   def encode_type({:enum, type}, n) when is_atom(n), do: n |> type.value() |> encode_varint()
   def encode_type({:enum, _}, n), do: encode_varint(n)
-  def encode_type(:float, :infinity), do: <<0, 0, 128, 127>>
-  def encode_type(:float, :negative_infinity), do: <<0, 0, 128, 255>>
-  def encode_type(:float, :nan), do: <<0, 0, 192, 127>>
+  def encode_type(:float, :infinity), do: [0, 0, 128, 127]
+  def encode_type(:float, :negative_infinity), do: [0, 0, 128, 255]
+  def encode_type(:float, :nan), do: [0, 0, 192, 127]
   def encode_type(:float, n), do: <<n::32-float-little>>
-  def encode_type(:double, :infinity), do: <<0, 0, 0, 0, 0, 0, 240, 127>>
-  def encode_type(:double, :negative_infinity), do: <<0, 0, 0, 0, 0, 0, 240, 255>>
-  def encode_type(:double, :nan), do: <<1, 0, 0, 0, 0, 0, 248, 127>>
+  def encode_type(:double, :infinity), do: [0, 0, 0, 0, 0, 0, 240, 127]
+  def encode_type(:double, :negative_infinity), do: [0, 0, 0, 0, 0, 0, 240, 255]
+  def encode_type(:double, :nan), do: [1, 0, 0, 0, 0, 0, 248, 127]
   def encode_type(:double, n), do: <<n::64-float-little>>
 
   def encode_type(:bytes, n) do
-    bin = IO.iodata_to_binary(n)
-    len = bin |> byte_size |> encode_varint
-    <<len::binary, bin::binary>>
+    len = n |> IO.iodata_length() |> encode_varint()
+    len ++ n
   end
 
   def encode_type(:sint32, n) when n >= -0x80000000 and n <= 0x7FFFFFFF,
@@ -202,18 +202,18 @@ defmodule Protobuf.Encoder do
   defp encode_zigzag(val) when val < 0, do: val * -2 - 1
 
   @doc false
-  @spec encode_varint(integer) :: iodata
+  @spec encode_varint(integer) :: iolist
   def encode_varint(n) when n < 0 do
     <<n::64-unsigned-native>> = <<n::64-signed-native>>
     encode_varint(n)
   end
 
   def encode_varint(n) when n <= 127 do
-    <<n>>
+    [n]
   end
 
   def encode_varint(n) do
-    [<<1::1, band(n, 127)::7>> | encode_varint(bsr(n, 7))] |> IO.iodata_to_binary()
+    [<<1::1, band(n, 127)::7>> | encode_varint(bsr(n, 7))]
   end
 
   @doc false

--- a/test/pbt/encode_decode_type_test.exs
+++ b/test/pbt/encode_decode_type_test.exs
@@ -13,7 +13,8 @@ defmodule Protobuf.EncodeDecodeTypeTest.PropertyGenerator do
     quote do
       property unquote(Atom.to_string(field_type)) <> " roundtrip" do
         forall n <- unquote(gen_func) do
-          bin = Encoder.encode_type(unquote(field_type), n)
+          iodata = Encoder.encode_type(unquote(field_type), n)
+          bin = IO.iodata_to_binary(iodata)
 
           ensure(
             n ==
@@ -35,14 +36,22 @@ defmodule Protobuf.EncodeDecodeTypeTest.PropertyGenerator do
     quote do
       property unquote(Atom.to_string(field_type)) <> " canonical roundtrip" do
         forall n <- unquote(gen_func) do
+          encoded_val =
+            unquote(field_type)
+            |> Encoder.encode_type(n)
+            |> IO.iodata_to_binary()
+
           canonical_val =
             decode_type(
               unquote(wire_type),
               unquote(field_type),
-              Encoder.encode_type(unquote(field_type), n)
+              encoded_val
             )
 
-          bin = Encoder.encode_type(unquote(field_type), canonical_val)
+          bin =
+            unquote(field_type)
+            |> Encoder.encode_type(canonical_val)
+            |> IO.iodata_to_binary()
 
           ensure(
             canonical_val ==

--- a/test/pbt/encode_decode_varint_test.exs
+++ b/test/pbt/encode_decode_varint_test.exs
@@ -6,7 +6,8 @@ defmodule Protobuf.EncodeDecodeVarintTest do
 
   property "varint roundtrip" do
     forall n <- largeint() do
-      bin = Encoder.encode_varint(n)
+      iodata = Encoder.encode_varint(n)
+      bin = IO.iodata_to_binary(iodata)
       [n] = Decoder.decode_varint(bin, :value)
       ensure(<<n::signed-64>> == <<n::64>>)
     end
@@ -18,7 +19,7 @@ defmodule Protobuf.EncodeDecodeVarintTest do
 
   property "encode_varint for negative integers should always be 10 bytes" do
     forall n <- neg_gen() do
-      ensure(byte_size(Encoder.encode_varint(n)) == 10)
+      ensure(IO.iodata_length(Encoder.encode_varint(n)) == 10)
     end
   end
 end

--- a/test/protobuf/encoder/encode_type_test.exs
+++ b/test/protobuf/encoder/encode_type_test.exs
@@ -7,214 +7,220 @@ defmodule Protobuf.Encoder.DecodeTypeTest do
   import Protobuf.Decoder
 
   test "encode_type/2 varint" do
-    assert Encoder.encode_type(:int32, 42) == <<42>>
+    assert encode(:int32, 42) == <<42>>
   end
 
   test "encode_type/2 min int32" do
-    assert Encoder.encode_type(:int32, -2_147_483_648) ==
+    assert encode(:int32, -2_147_483_648) ==
              <<128, 128, 128, 128, 248, 255, 255, 255, 255, 1>>
   end
 
   test "encode_type/2 min int64" do
-    assert Encoder.encode_type(:int64, -9_223_372_036_854_775_808) ==
+    assert encode(:int64, -9_223_372_036_854_775_808) ==
              <<128, 128, 128, 128, 128, 128, 128, 128, 128, 1>>
   end
 
   test "encode_type/3 min sint32" do
-    assert Encoder.encode_type(:sint32, -2_147_483_648) == <<255, 255, 255, 255, 15>>
+    assert encode(:sint32, -2_147_483_648) == <<255, 255, 255, 255, 15>>
   end
 
   test "encode_type/3 max sint32" do
-    assert Encoder.encode_type(:sint32, 2_147_483_647) == <<254, 255, 255, 255, 15>>
+    assert encode(:sint32, 2_147_483_647) == <<254, 255, 255, 255, 15>>
   end
 
   test "encode_type/3 min sint64" do
-    assert Encoder.encode_type(:sint64, -9_223_372_036_854_775_808) ==
+    assert encode(:sint64, -9_223_372_036_854_775_808) ==
              <<255, 255, 255, 255, 255, 255, 255, 255, 255, 1>>
   end
 
   test "encode_type/3 max sint64" do
-    assert Encoder.encode_type(:sint64, 9_223_372_036_854_775_807) ==
+    assert encode(:sint64, 9_223_372_036_854_775_807) ==
              <<254, 255, 255, 255, 255, 255, 255, 255, 255, 1>>
   end
 
   test "encode_type/3 bool false" do
-    assert Encoder.encode_type(:bool, false) == <<0>>
+    assert encode(:bool, false) == <<0>>
   end
 
   test "encode_type/3 bool true" do
-    assert Encoder.encode_type(:bool, true) == <<1>>
+    assert encode(:bool, true) == <<1>>
   end
 
   test "encode_type/3 a fixed64" do
-    assert Encoder.encode_type(:fixed64, 8_446_744_073_709_551_615) ==
+    assert encode(:fixed64, 8_446_744_073_709_551_615) ==
              <<255, 255, 23, 118, 251, 220, 56, 117>>
   end
 
   test "encode_type/3 max fixed64" do
-    assert Encoder.encode_type(:fixed64, 18_446_744_073_709_551_615) ==
+    assert encode(:fixed64, 18_446_744_073_709_551_615) ==
              <<255, 255, 255, 255, 255, 255, 255, 255>>
   end
 
   test "encode_type/3 min sfixed64" do
-    assert Encoder.encode_type(:sfixed64, -9_223_372_036_854_775_808) ==
+    assert encode(:sfixed64, -9_223_372_036_854_775_808) ==
              <<0, 0, 0, 0, 0, 0, 0, 128>>
   end
 
   test "encode_type/3 max sfixed64" do
-    assert Encoder.encode_type(:sfixed64, 9_223_372_036_854_775_807) ==
+    assert encode(:sfixed64, 9_223_372_036_854_775_807) ==
              <<255, 255, 255, 255, 255, 255, 255, 127>>
   end
 
   test "encode_type/3 min double" do
-    assert Encoder.encode_type(:double, 5.0e-324) == <<1, 0, 0, 0, 0, 0, 0, 0>>
+    assert encode(:double, 5.0e-324) == <<1, 0, 0, 0, 0, 0, 0, 0>>
   end
 
   test "encode_type/3 max double" do
-    assert Encoder.encode_type(:double, 1.7976931348623157e308) ==
+    assert encode(:double, 1.7976931348623157e308) ==
              <<255, 255, 255, 255, 255, 255, 239, 127>>
   end
 
   test "encode_type/3 int as double" do
-    assert Encoder.encode_type(:double, -9_223_372_036_854_775_808) ==
+    assert encode(:double, -9_223_372_036_854_775_808) ==
              <<0, 0, 0, 0, 0, 0, 224, 195>>
   end
 
   test "encode_type/3 string" do
-    assert Encoder.encode_type(:string, "testing") == <<7, 116, 101, 115, 116, 105, 110, 103>>
+    assert encode(:string, "testing") == <<7, 116, 101, 115, 116, 105, 110, 103>>
   end
 
   test "encode_type/3 bytes" do
-    assert Encoder.encode_type(:bytes, <<42, 43, 44, 45>>) == <<4, 42, 43, 44, 45>>
+    assert encode(:bytes, <<42, 43, 44, 45>>) == <<4, 42, 43, 44, 45>>
   end
 
   test "encode_type/3 fixed32" do
-    assert Encoder.encode_type(:fixed32, 4_294_967_295) == <<255, 255, 255, 255>>
+    assert encode(:fixed32, 4_294_967_295) == <<255, 255, 255, 255>>
   end
 
   test "encode_type/3 sfixed32" do
-    assert Encoder.encode_type(:sfixed32, 2_147_483_647) == <<255, 255, 255, 127>>
+    assert encode(:sfixed32, 2_147_483_647) == <<255, 255, 255, 127>>
   end
 
   test "encode_type/3 float" do
-    assert Encoder.encode_type(:float, 3.4028234663852886e38) == <<255, 255, 127, 127>>
+    assert encode(:float, 3.4028234663852886e38) == <<255, 255, 127, 127>>
   end
 
   test "encode_type/3 int as float" do
-    assert Encoder.encode_type(:float, 3) == <<0, 0, 64, 64>>
+    assert encode(:float, 3) == <<0, 0, 64, 64>>
   end
 
   test "encode_type/3 float infinity/-infinity/nan" do
     Enum.each([:infinity, :negative_infinity, :nan], fn f ->
-      bin = Encoder.encode_type(:float, f)
+      bin = encode(:float, f)
       assert f == Decoder.decode_type_m(:float, :fake, bin)
     end)
   end
 
   test "encode_type/3 double infinity/-infinity/nan" do
     Enum.each([:infinity, :negative_infinity, :nan], fn f ->
-      bin = Encoder.encode_type(:double, f)
+      bin = encode(:double, f)
       assert f == Decoder.decode_type_m(:double, :fake, bin)
     end)
   end
 
   test "encode_type/2 wrong uint32" do
     assert_raise Protobuf.TypeEncodeError, fn ->
-      Encoder.encode_type(:uint32, 12_345_678_901_234_567_890)
+      encode(:uint32, 12_345_678_901_234_567_890)
     end
 
     assert_raise Protobuf.TypeEncodeError, fn ->
-      Encoder.encode_type(:uint32, -1)
+      encode(:uint32, -1)
     end
   end
 
   test "encode_type/2 wrong uint64" do
     assert_raise Protobuf.TypeEncodeError, fn ->
-      Encoder.encode_type(:uint64, 184_467_440_737_095_516_150)
+      encode(:uint64, 184_467_440_737_095_516_150)
     end
 
     assert_raise Protobuf.TypeEncodeError, fn ->
-      Encoder.encode_type(:uint64, -1)
+      encode(:uint64, -1)
     end
   end
 
   test "encode_type/2 wrong fixed32" do
     assert_raise Protobuf.TypeEncodeError, fn ->
-      Encoder.encode_type(:fixed32, 12_345_678_901_234_567_890)
+      encode(:fixed32, 12_345_678_901_234_567_890)
     end
 
     assert_raise Protobuf.TypeEncodeError, fn ->
-      Encoder.encode_type(:fixed32, -1)
+      encode(:fixed32, -1)
     end
   end
 
   test "encode_type/2 wrong fixed64" do
     assert_raise Protobuf.TypeEncodeError, fn ->
-      Encoder.encode_type(:fixed64, 184_467_440_737_095_516_150)
+      encode(:fixed64, 184_467_440_737_095_516_150)
     end
 
     assert_raise Protobuf.TypeEncodeError, fn ->
-      Encoder.encode_type(:fixed64, -1)
+      encode(:fixed64, -1)
     end
   end
 
   test "encode_type/2 wrong int32" do
     assert_raise Protobuf.TypeEncodeError, fn ->
-      Encoder.encode_type(:int32, 2_147_483_648)
+      encode(:int32, 2_147_483_648)
     end
 
     assert_raise Protobuf.TypeEncodeError, fn ->
-      Encoder.encode_type(:int32, -2_147_483_649)
+      encode(:int32, -2_147_483_649)
     end
   end
 
   test "encode_type/2 wrong int64" do
     assert_raise Protobuf.TypeEncodeError, fn ->
-      Encoder.encode_type(:int64, 184_467_440_737_095_516_150)
+      encode(:int64, 184_467_440_737_095_516_150)
     end
 
     assert_raise Protobuf.TypeEncodeError, fn ->
-      Encoder.encode_type(:int64, -184_467_440_737_095_516_150)
+      encode(:int64, -184_467_440_737_095_516_150)
     end
   end
 
   test "encode_type/2 wrong sint32" do
     assert_raise Protobuf.TypeEncodeError, fn ->
-      Encoder.encode_type(:sint32, 2_147_483_648)
+      encode(:sint32, 2_147_483_648)
     end
 
     assert_raise Protobuf.TypeEncodeError, fn ->
-      Encoder.encode_type(:sint32, -2_147_483_649)
+      encode(:sint32, -2_147_483_649)
     end
   end
 
   test "encode_type/2 wrong sint64" do
     assert_raise Protobuf.TypeEncodeError, fn ->
-      Encoder.encode_type(:sint64, 184_467_440_737_095_516_150)
+      encode(:sint64, 184_467_440_737_095_516_150)
     end
 
     assert_raise Protobuf.TypeEncodeError, fn ->
-      Encoder.encode_type(:sint64, -184_467_440_737_095_516_150)
+      encode(:sint64, -184_467_440_737_095_516_150)
     end
   end
 
   test "encode_type/2 wrong sfixed32" do
     assert_raise Protobuf.TypeEncodeError, fn ->
-      Encoder.encode_type(:sfixed32, 2_147_483_648)
+      encode(:sfixed32, 2_147_483_648)
     end
 
     assert_raise Protobuf.TypeEncodeError, fn ->
-      Encoder.encode_type(:sfixed32, -2_147_483_649)
+      encode(:sfixed32, -2_147_483_649)
     end
   end
 
   test "encode_type/2 wrong sfixed64" do
     assert_raise Protobuf.TypeEncodeError, fn ->
-      Encoder.encode_type(:sfixed64, 184_467_440_737_095_516_150)
+      encode(:sfixed64, 184_467_440_737_095_516_150)
     end
 
     assert_raise Protobuf.TypeEncodeError, fn ->
-      Encoder.encode_type(:sfixed64, -184_467_440_737_095_516_150)
+      encode(:sfixed64, -184_467_440_737_095_516_150)
     end
+  end
+
+  def encode(type, value) do
+    type
+    |> Encoder.encode_type(value)
+    |> IO.iodata_to_binary()
   end
 end

--- a/test/protobuf/encoder/encode_type_test.exs
+++ b/test/protobuf/encoder/encode_type_test.exs
@@ -218,7 +218,7 @@ defmodule Protobuf.Encoder.DecodeTypeTest do
     end
   end
 
-  def encode(type, value) do
+  defp encode(type, value) do
     type
     |> Encoder.encode_type(value)
     |> IO.iodata_to_binary()

--- a/test/protobuf/encoder/encode_varint_test.exs
+++ b/test/protobuf/encoder/encode_varint_test.exs
@@ -43,7 +43,7 @@ defmodule Protobuf.Encoder.DecodeVarintTest do
              <<255, 255, 255, 255, 255, 255, 255, 255, 255, 1>>
   end
 
-  def encode(varint) do
+  defp encode(varint) do
     varint
     |> Encoder.encode_varint()
     |> IO.iodata_to_binary()

--- a/test/protobuf/encoder/encode_varint_test.exs
+++ b/test/protobuf/encoder/encode_varint_test.exs
@@ -4,42 +4,48 @@ defmodule Protobuf.Encoder.DecodeVarintTest do
   alias Protobuf.Encoder
 
   test "encode_varint 300" do
-    assert Encoder.encode_varint(300) == <<0b1010110000000010::16>>
+    assert encode(300) == <<0b1010110000000010::16>>
   end
 
   test "encode_varint 150" do
-    assert Encoder.encode_varint(150) == <<150, 1>>
+    assert encode(150) == <<150, 1>>
   end
 
   test "encode_varint 0" do
-    assert Encoder.encode_varint(0) == <<0>>
+    assert encode(0) == <<0>>
   end
 
   test "encode_varint/2 min int32" do
-    assert Encoder.encode_varint(-2_147_483_648) ==
+    assert encode(-2_147_483_648) ==
              <<128, 128, 128, 128, 248, 255, 255, 255, 255, 1>>
   end
 
   test "encode_varint max int32" do
-    assert Encoder.encode_varint(2_147_483_647) == <<255, 255, 255, 255, 7>>
+    assert encode(2_147_483_647) == <<255, 255, 255, 255, 7>>
   end
 
   test "encode_varint/2 min int64" do
-    assert Encoder.encode_varint(-9_223_372_036_854_775_808) ==
+    assert encode(-9_223_372_036_854_775_808) ==
              <<128, 128, 128, 128, 128, 128, 128, 128, 128, 1>>
   end
 
   test "encode_varint max int64" do
-    assert Encoder.encode_varint(9_223_372_036_854_775_807) ==
+    assert encode(9_223_372_036_854_775_807) ==
              <<255, 255, 255, 255, 255, 255, 255, 255, 127>>
   end
 
   test "encode_varint max uint32" do
-    assert Encoder.encode_varint(4_294_967_295) == <<255, 255, 255, 255, 15>>
+    assert encode(4_294_967_295) == <<255, 255, 255, 255, 15>>
   end
 
   test "encode_varint max uint64" do
-    assert Encoder.encode_varint(18_446_744_073_709_551_615) ==
+    assert encode(18_446_744_073_709_551_615) ==
              <<255, 255, 255, 255, 255, 255, 255, 255, 255, 1>>
+  end
+
+  def encode(varint) do
+    varint
+    |> Encoder.encode_varint()
+    |> IO.iodata_to_binary()
   end
 end


### PR DESCRIPTION
Reducing the amount of intermediate binaries allocated speeds up encoding and potentially decreases memory usage.

I'm usually very distrustful of local benchmarks, so it'd be very reassuring to see some production numbers with these optimizations applied. Anyway, these are the results I've got running against `master`:

```
##### With input google_message1_proto3 #####
Name                                                ips        average  deviation         median         99th %
encode (optimized)                              24.24 K       41.26 μs  ±4792.01%           0 μs           0 μs
encode (master)                                 10.70 K       93.47 μs  ±2984.15%          12 μs          32 μs

Comparison: 
encode (optimized)                              24.24 K
encode (master)                                 10.70 K - 2.27x slower +52.21 μs

Memory usage statistics:

Name                                         Memory usage
encode (optimized)                                2.78 KB
encode (master)                                   3.55 KB - 1.28x memory usage +0.77 KB

**All measurements for memory usage were the same**

##### With input google_message1_proto2 #####
Name                                                ips        average  deviation         median         99th %
encode (optimized)                              13.94 K       71.71 μs  ±3642.67%           0 μs           0 μs
encode (master)                                  6.28 K      159.30 μs  ±2283.59%          22 μs          77 μs

Comparison: 
encode (optimized)                              13.94 K
encode (master)                                  6.28 K - 3.86x slower +118.05 μs

Memory usage statistics:

Name                                         Memory usage
encode (optimized)                                7.49 KB
encode (master)                                   9.59 KB - 3.45x memory usage +6.80 KB

**All measurements for memory usage were the same**

##### With input google_message3_3 #####
Name                                                ips        average  deviation         median         99th %
encode (optimized)                              13.63 K       73.38 μs  ±3569.64%           0 μs           0 μs
encode (master)                                  6.05 K      165.20 μs  ±2330.28%           6 μs       18.76 μs

Comparison: 
encode (optimized)                              13.63 K
encode (master)                                  6.05 K - 4.00x slower +123.95 μs

Memory usage statistics:

Name                                         Memory usage
encode (optimized)                                1.82 KB
encode (master)                                   2.38 KB - 0.85x memory usage -0.40625 KB

**All measurements for memory usage were the same**

##### With input google_message3_5 #####
Name                                                ips        average  deviation         median         99th %
encode (optimized)                               8.36 K      119.66 μs  ±2753.18%           0 μs           0 μs
encode (master)                                  2.85 K      351.17 μs  ±1616.63%           4 μs          21 μs

Comparison: 
encode (optimized)                               8.36 K
encode (master)                                  2.85 K - 8.51x slower +309.91 μs

Memory usage statistics:

Name                                         Memory usage
encode (optimized)                                0.99 KB
encode (master)                                   1.17 KB - 0.42x memory usage -1.60938 KB

**All measurements for memory usage were the same**

##### With input google_message2 #####
Name                                                ips        average  deviation         median         99th %
encode (optimized)                               5.39 K      185.37 μs  ±2236.82%           0 μs           0 μs
encode (master)                                  3.18 K      314.79 μs  ±1696.43%          11 μs          53 μs

Comparison: 
encode (optimized)                               5.39 K
encode (master)                                  3.18 K - 7.63x slower +273.54 μs

Memory usage statistics:

Name                                         Memory usage
encode (optimized)                                3.84 KB
encode (master)                                   4.66 KB - 1.68x memory usage +1.88 KB

**All measurements for memory usage were the same**

##### With input google_message3_4 #####
Name                                                ips        average  deviation         median         99th %
encode (optimized)                                93.04       10.75 ms   ±277.06%           0 ms       92.24 ms
encode (master)                                   22.02       45.42 ms   ±171.95%      0.0780 ms      186.03 ms

Comparison: 
encode (optimized)                                93.04
encode (master)                                   22.02 - 1100.88x slower +45.38 ms

Memory usage statistics:

Name                                         Memory usage
encode (optimized)                                1.10 KB
encode (master)                                   1.30 KB - 0.47x memory usage -1.48438 KB

**All measurements for memory usage were the same**

##### With input google_message3_2 #####
Name                                                ips        average  deviation         median         99th %
encode (optimized)                                43.28       23.10 ms   ±164.40%        2.91 ms       98.60 ms
encode (master)                                    9.75      102.53 ms   ±235.95%        4.02 ms     1838.17 ms

Comparison: 
encode (optimized)                                43.28
encode (master)                                    9.75 - 2485.19x slower +102.49 ms

Memory usage statistics:

Name                                         Memory usage
encode (optimized)                                1.10 MB
encode (master)                                   1.47 MB - 542.00x memory usage +1.47 MB

**All measurements for memory usage were the same**

##### With input google_message4 #####
Name                                                ips        average  deviation         median         99th %
encode (master)                                   11.48       87.12 ms    ±47.58%       93.15 ms      264.19 ms
encode (optimized)                                 6.02      166.08 ms    ±76.96%      267.27 ms      276.12 ms

Comparison: 
encode (master)                                   11.48
encode (optimized)                                 6.02 - 4025.58x slower +166.04 ms

Memory usage statistics:

Name                                         Memory usage
encode (master)                                   3.51 KB
encode (optimized)                                2.80 KB - 1.01x memory usage +0.0234 KB

**All measurements for memory usage were the same**

##### With input google_message3_1 #####
Name                                                ips        average  deviation         median         99th %
encode (optimized)                                 0.26     0.0648 min    ±23.43%     0.0569 min     0.0898 min
encode (master)                                 0.00439       3.79 min     ±0.00%       3.79 min       3.79 min

Comparison: 
encode (optimized)                                 0.26
encode (master)                                 0.00439 - 5519124.47x slower +3.79 min

Memory usage statistics:

Name                                         Memory usage
encode (optimized)                              439.80 MB
encode (master)                                 743.91 MB - 273891.43x memory usage +743.90 MB

**All measurements for memory usage were the same**
``` 