### PR TITLE
Tweak benchmark scripts

### DIFF
--- a/bench/script/bench.exs
+++ b/bench/script/bench.exs
@@ -6,6 +6,8 @@ tag = "#{String.trim(head)}-#{String.trim(hash)}"
 opts = fn name, inputs ->
   [
     inputs: inputs,
+    time: 20,
+    memory_time: 5,
     save: [path: "benchmarks/#{tag}-#{name}.benchee", tag: "#{tag}-#{name}"],
     formatters: [Benchee.Formatters.Console]
   ]
@@ -13,11 +15,10 @@ end
 
 benches =
   for path <- Path.wildcard("data/*.pb"),
-      # Skipping this particular message for now because it takes too long.
-      path != "data/dataset.google_message3_1.pb",
-      %{payload: [payload | _], name: name, message_name: mod_name} = ProtoBench.load(path),
-      module = ProtoBench.mod_name(mod_name),
-      do: {name, module, payload}
+      bench = ProtoBench.load(path),
+      payload = Enum.max_by(bench.payload, &byte_size/1),
+      module = ProtoBench.mod_name(bench.message_name),
+      do: {bench.name, module, payload}
 
 decode =
   for {name, module, payload} <- benches,

--- a/bench/script/load.exs
+++ b/bench/script/load.exs
@@ -2,12 +2,18 @@ Benchee.run(
   %{},
   load: "benchmarks/*-decode.benchee",
   print: [configuration: false],
-  formatters: [{Benchee.Formatters.HTML, file: "benchmarks/output/decode.html"}]
+  formatters: [
+    Benchee.Formatters.Console,
+    {Benchee.Formatters.HTML, file: "benchmarks/output/decode.html"}
+  ]
 )
 
 Benchee.run(
   %{},
   load: "benchmarks/*-encode.benchee",
   print: [configuration: false],
-  formatters: [{Benchee.Formatters.HTML, file: "benchmarks/output/encode.html"}]
+  formatters: [
+    Benchee.Formatters.Console,
+    {Benchee.Formatters.HTML, file: "benchmarks/output/encode.html"}
+  ]
 )


### PR DESCRIPTION
Separating part of #118 into its own PR to make local testing easier for everyone.

* Increase run time for more accuracy
* Enable memory measurements
* Bring back `google_message3_1`, even though it may go over the established run time
* Select the longest payload rather than the first one
* Output comparison to console in addition to HTML