### PR TITLE
Optimize decoding of keys and packed fields

### DIFF
--- a/lib/protobuf/decoder.ex
+++ b/lib/protobuf/decoder.ex
@@ -372,11 +372,11 @@ defmodule Protobuf.Decoder do
     raw_decode_varint(bin, result, :packed, groups)
   end
 
-  defp raw_handle_key(wire_start_group(), opening, groups, bin, result) do
+  defp raw_handle_key(wire_start_group(), opening, groups, <<bin::bits>>, result) do
     raw_decode_key(bin, result, [opening | groups])
   end
 
-  defp raw_handle_key(wire_end_group(), closing, [closing | groups], bin, result) do
+  defp raw_handle_key(wire_end_group(), closing, [closing | groups], <<bin::bits>>, result) do
     raw_decode_key(bin, result, groups)
   end
 
@@ -392,11 +392,11 @@ defmodule Protobuf.Decoder do
     )
   end
 
-  defp raw_handle_key(wire_type, tag, [], bin, result) do
+  defp raw_handle_key(wire_type, tag, [], <<bin::bits>>, result) do
     raw_decode_value(wire_type, bin, [wire_type, tag | result], [])
   end
 
-  defp raw_handle_key(wire_type, _tag, groups, bin, result) do
+  defp raw_handle_key(wire_type, _tag, groups, <<bin::bits>>, result) do
     raw_decode_value(wire_type, bin, result, groups)
   end
 

--- a/lib/protobuf/decoder.ex
+++ b/lib/protobuf/decoder.ex
@@ -361,15 +361,10 @@ defmodule Protobuf.Decoder do
     raw_decode_key(rest, result, groups)
   end
 
-  defp raw_handle_varint(:packed, <<>>, result, val, []), do: [val | result]
-  defp raw_handle_varint(:packed, <<>>, result, _val, _groups), do: result
+  defp raw_handle_varint(:packed, <<>>, result, val, _groups), do: [val | result]
 
-  defp raw_handle_varint(:packed, <<bin::bits>>, result, val, []) do
-    raw_decode_varint(bin, [val | result], :packed, [])
-  end
-
-  defp raw_handle_varint(:packed, <<bin::bits>>, result, _val, groups) do
-    raw_decode_varint(bin, result, :packed, groups)
+  defp raw_handle_varint(:packed, <<bin::bits>>, result, val, groups) do
+    raw_decode_varint(bin, [val | result], :packed, groups)
   end
 
   defp raw_handle_key(wire_start_group(), opening, groups, <<bin::bits>>, result) do


### PR DESCRIPTION
Benchmark results:

```
##### With input google_message1_proto2 #####
Name                                              ips        average  deviation         median         99th %
decode (optimize-packed-99926e5-decode)       61.33 K       16.31 μs   ±963.31%           8 μs          30 μs
decode (master-3428d3a-decode)                51.89 K       19.27 μs   ±883.01%           9 μs          37 μs

Comparison: 
decode (optimize-packed-99926e5-decode)       61.33 K
decode (master-3428d3a-decode)                51.89 K - 6.59x slower +16.35 μs

Memory usage statistics:

Name                                       Memory usage
decode (optimize-packed-99926e5-decode)         6.84 KB
decode (master-3428d3a-decode)                  8.48 KB - 9.44x memory usage +7.59 KB

##### With input google_message1_proto3 #####
Name                                              ips        average  deviation         median         99th %
decode (optimize-packed-99926e5-decode)       63.38 K       15.78 μs  ±1019.98%           8 μs          21 μs
decode (master-3428d3a-decode)                54.42 K       18.38 μs   ±939.82%           9 μs          20 μs

Comparison: 
decode (optimize-packed-99926e5-decode)       63.38 K
decode (master-3428d3a-decode)                54.42 K - 6.29x slower +15.45 μs

Memory usage statistics:

Name                                       Memory usage
decode (optimize-packed-99926e5-decode)         6.84 KB
decode (master-3428d3a-decode)                  8.48 KB - 9.44x memory usage +7.59 KB

##### With input google_message2 #####
Name                                              ips        average  deviation         median         99th %
decode (optimize-packed-99926e5-decode)        864.75        1.16 ms     ±4.05%        1.16 ms        1.28 ms
decode (master-3428d3a-decode)                 687.49        1.45 ms     ±6.05%        1.45 ms        1.68 ms

Comparison: 
decode (optimize-packed-99926e5-decode)        864.75
decode (master-3428d3a-decode)                 687.49 - 497.55x slower +1.45 ms

Memory usage statistics:

Name                                       Memory usage
decode (optimize-packed-99926e5-decode)        23.74 KB
decode (master-3428d3a-decode)                731.05 KB - 813.69x memory usage +730.15 KB

##### With input google_message3_1 #####
Name                                              ips        average  deviation         median         99th %
decode (optimize-packed-99926e5-decode)         0.135         7.42 s     ±1.45%         7.36 s         7.55 s
decode (master-3428d3a-decode)                  0.118         8.50 s     ±0.44%         8.52 s         8.53 s

Comparison: 
decode (optimize-packed-99926e5-decode)         0.135
decode (master-3428d3a-decode)                  0.118 - 2908349.55x slower +8.50 s

Memory usage statistics:

Name                                       Memory usage
decode (optimize-packed-99926e5-decode)         1.67 GB
decode (master-3428d3a-decode)                  2.05 GB - 2389926.57x memory usage +2.05 GB

##### With input google_message3_2 #####
Name                                              ips        average  deviation         median         99th %
decode (optimize-packed-99926e5-decode)         90.47       11.05 ms     ±3.35%       11.01 ms       12.05 ms
decode (master-3428d3a-decode)                  75.38       13.27 ms     ±2.65%       13.23 ms       14.03 ms

Comparison: 
decode (optimize-packed-99926e5-decode)         90.47
decode (master-3428d3a-decode)                  75.38 - 4537.74x slower +13.26 ms

Memory usage statistics:

Name                                       Memory usage
decode (optimize-packed-99926e5-decode)         2.89 MB
decode (master-3428d3a-decode)                  7.26 MB - 8275.49x memory usage +7.26 MB

##### With input google_message3_3 #####
Name                                              ips        average  deviation         median         99th %
decode (optimize-packed-99926e5-decode)      177.29 K        5.64 μs  ±2641.69%           3 μs           7 μs
decode (master-3428d3a-decode)               151.92 K        6.58 μs  ±2447.36%           3 μs           6 μs

Comparison: 
decode (optimize-packed-99926e5-decode)      177.29 K
decode (master-3428d3a-decode)               151.92 K - 2.25x slower +3.66 μs

Memory usage statistics:

Name                                       Memory usage
decode (optimize-packed-99926e5-decode)         1.88 KB
decode (master-3428d3a-decode)                  2.52 KB - 2.81x memory usage +1.63 KB

##### With input google_message3_4 #####
Name                                              ips        average  deviation         median         99th %
decode (optimize-packed-99926e5-decode)      336.87 K        2.97 μs  ±4976.75%           1 μs           4 μs
decode (master-3428d3a-decode)               286.98 K        3.48 μs  ±4476.92%           2 μs           4 μs

Comparison: 
decode (optimize-packed-99926e5-decode)      336.87 K
decode (master-3428d3a-decode)               286.98 K - 1.19x slower +0.56 μs

Memory usage statistics:

Name                                       Memory usage
decode (optimize-packed-99926e5-decode)         0.90 KB
decode (master-3428d3a-decode)                  1.25 KB - 1.39x memory usage +0.35 KB

##### With input google_message3_5 #####
Name                                              ips        average  deviation         median         99th %
decode (optimize-packed-99926e5-decode)      342.06 K        2.92 μs  ±5211.57%           1 μs           4 μs
decode (master-3428d3a-decode)               287.16 K        3.48 μs  ±4507.40%           2 μs           4 μs

Comparison: 
decode (optimize-packed-99926e5-decode)      342.06 K
decode (master-3428d3a-decode)               287.16 K - 1.19x slower +0.56 μs

Memory usage statistics:

Name                                       Memory usage
decode (optimize-packed-99926e5-decode)         0.90 KB
decode (master-3428d3a-decode)                  1.25 KB - 1.39x memory usage +0.35 KB

##### With input google_message4 #####
Name                                              ips        average  deviation         median         99th %
decode (optimize-packed-99926e5-decode)      143.56 K        6.97 μs  ±2087.90%           4 μs           6 μs
decode (master-3428d3a-decode)               121.78 K        8.21 μs  ±1876.36%           4 μs           9 μs

Comparison: 
decode (optimize-packed-99926e5-decode)      143.56 K
decode (master-3428d3a-decode)               121.78 K - 2.81x slower +5.29 μs

Memory usage statistics:

Name                                       Memory usage
decode (optimize-packed-99926e5-decode)         2.31 KB
decode (master-3428d3a-decode)                  3.02 KB - 3.37x memory usage +2.13 KB
```